### PR TITLE
WIP: Implement method calls with :

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -287,7 +287,7 @@ local function parse(getbyte, state)
             elseif rawstr == 'true' then dispatch(true)
             elseif rawstr == 'false' then dispatch(false)
             elseif rawstr == '...' then dispatch(VARARG)
-            elseif rawstr:match('^:[%w_-]*$') then -- keyword style strings
+            elseif rawstr:match('^:[%w_-]+$') then -- keyword style strings
                 dispatch(rawstr:sub(2))
             else
                 local forceNumber = rawstr:match('^%d')
@@ -1067,6 +1067,16 @@ SPECIALS['for'] = function(ast, scope, parent)
     compileDo(ast, subScope, chunk, 3)
     parent[#parent + 1] = chunk
     parent[#parent + 1] = 'end'
+end
+
+SPECIALS[':'] = function(ast, scope, parent)
+    local method = ast[3]
+    ast[1] = list(sym("."), ast[2], method)
+    table.remove(ast, 3)
+    ast.n = ast.n - 1
+    local call = compile1(ast, scope, parent)
+    call[1].type = "expression" -- this seems to have no effect
+    parent[#parent + 1] = call
 end
 
 -- Do we need this? Is there a more elegnant way to compile with break?

--- a/test.lua
+++ b/test.lua
@@ -21,6 +21,7 @@ local cases = {
         ["(let [[ok e] [(pcall (lambda [x] (+ x 2)))]]\
             (string.match e \"Missing argument: x\"))"]="Missing argument: x",
         ["(let [[ok val] [(pcall (λ [?x] (+ (or ?x 1) 8)))]] (and ok val))"]=9,
+        ["(let [s \"method\"] (: s :find \"hod\"))"]=4,
     },
 
     conditionals = {


### PR DESCRIPTION
A couple things to note here. At first I wasn't even sure we should support method call syntax, but there are enough libraries out there that assume it, I think.

I'm not totally sold on the syntax, but what I came up with was `(: receiver :method ...)` compiles to `receiver:method(...)`. Open for suggestions on how to improve that; perhaps just `(receiver:method ...)` would be better? But that complicates things as it's no longer just another special form.

I couldn't figure out how to indicate to the compiler that the result should be treated as an expression rather than a statement, as you can see from the failing test.