### PR TITLE
Line numbers for compile errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,19 @@ chunk when called. Useful for implementing a repl.
 local bytestream, clearstream = fennel.granulate(chunks)
 ```
     
-Get the next top level value parsed from a stream of
-bytes. Returns true in the first return value if a value was read, and
+Converts a stream of bytes to a stream of values.
+Valuestream gets the next top level value parsed.
+Returns true in the first return value if a value was read, and
 returns nil if and end of file was reached without error. Will error
 on bad input or unexpected end of source.
 ```lua
-local ok, value = fennel.parse(strm)
+local valuestream = fennel.parser(strm)
+local ok, value = valuestream()
+
+-- Or use in a for loop
+for ok, value in valuestream do
+    print(ok, value)
+end
 ```
 
 Compile a data structure (AST) into Lua source code. The code can be loaded

--- a/fennel
+++ b/fennel
@@ -17,14 +17,18 @@ if arg[1] == "--repl" or #arg == 0 then
 elseif arg[1] == "--compile" then
     for i = 2, #arg do
         local f = assert(io.open(arg[i], "rb"))
-        print(fennel.compileString(f:read("*all")))
+        local ok, val = pcall(fennel.compileString, f:read("*all"))
+        print(val)
+        if(not ok) then os.exit(1) end
         f:close()
     end
 elseif #arg == 1 then
     local filename = table.remove(arg, 1) -- let the script have remaining args
     local f = io.open(filename, "rb")
     if f then
-        fennel.eval(f:read("*all"), {filename = filename})
+        local ok, val = pcall(fennel.eval, f:read("*all"), {filename=filename})
+        print(val)
+        if(not ok) then os.exit(1) end
         f:close()
     else
         print(help)

--- a/fennel
+++ b/fennel
@@ -17,7 +17,8 @@ if arg[1] == "--repl" or #arg == 0 then
 elseif arg[1] == "--compile" then
     for i = 2, #arg do
         local f = assert(io.open(arg[i], "rb"))
-        local ok, val = pcall(fennel.compileString, f:read("*all"))
+        local ok, val = pcall(fennel.compileString, f:read("*all"),
+                              {filename=arg[1]})
         print(val)
         if(not ok) then os.exit(1) end
         f:close()

--- a/fennel.lua
+++ b/fennel.lua
@@ -312,7 +312,7 @@ end
 
 --
 -- Compilation
--- 
+--
 
 -- Creat a new Scope, optionally under a parent scope. Scopes are compile time constructs
 -- that are responsible for keeping track of local variables, name mangling, and macros.
@@ -657,7 +657,7 @@ local function destructure1(left, rightexprs, scope, parent, nonlocal)
         end
         parent[#parent + 1] = (setter):
             format(table.concat(leftNames, ", "), exprs1(rightexprs))
-        for i, pair in pairs(tables) do -- recurse if left-side tables found
+        for _, pair in pairs(tables) do -- recurse if left-side tables found
             destructure1(pair[1], {pair[2]}, scope, parent, nonlocal)
         end
     else

--- a/fennel.lua
+++ b/fennel.lua
@@ -351,7 +351,7 @@ end
 -- Assert a condition and emit a compile error with line numbers. The ast arg
 -- should be unmodified so that its first element is the form being called.
 local function assertCompile(condition, msg, ast)
-    return assert(condition, string.format("Compile error in `%s' %s:%s - %s",
+    return assert(condition, string.format("Compile error in `%s' %s:%s: %s",
                                            ast[1][1], filename or "unknown",
                                            ast.line, msg))
 end

--- a/test.lua
+++ b/test.lua
@@ -50,7 +50,7 @@ local cases = {
         ["((lambda [x ...] (+ x 2)) 4)"]=6,
         -- lambdas perform arity checks
         ["(let [(ok e) (pcall (lambda [x] (+ x 2)))]\
-            (string.match e \"Missing argument: x\"))"]="Missing argument: x",
+            (string.match e \"Missing argument x\"))"]="Missing argument x",
         -- lambda arity checks skip argument names starting with ?
         ["(let [(ok val) (pcall (λ [?x] (+ (or ?x 1) 8)))] (and ok val))"]=9,
     },
@@ -145,11 +145,16 @@ local compile_failures = {
     ["(f"]="unexpected end of source",
     ["(+))"]="unexpected closing delimiter",
     ["(fn)"]="expected vector arg list",
+    ["(fn [12])"]="expected symbol for function parameter",
     ["(lambda [x])"]="missing body",
     ["(let [x 1])"]="missing body",
-    ["(. tbl)"]="table and key argument",
-    ["(each [x 34 (pairs {})] 21)"]="expected iterator symbol",
-    ["(for [32 34 32] 21)"]="expected iterator symbol",
+    -- line numbers
+    ["(set)"]="Compile error in `set' unknown:1: expected name and value",
+    ["(let [b 9\nq (. tbl)] q)"]="2: expected table and key argument",
+    ["(do\n\n\n(each \n[x 34 (pairs {})] 21))"]="4: expected iterator symbol",
+    ["(fn []\n(for [32 34 32] 21))"]="2: expected iterator symbol",
+    ["\n\n(let [f (lambda []\n(local))] (f))"]="4: expected name and value",
+    ["(do\n\n\n(each \n[x (pairs {})] (when)))"]="5: expected body",
 }
 
 print("Running tests for compile errors...")


### PR DESCRIPTION
This doesn't solve "line numbers" in general, but for compile-time errors we should have enough data to emit error messages with useful filename/line number details.

This uses `line` and `filename` as top-level locals and adds a `line` field to all AST lists created in the parser. The ast is passed to `assertCompile` which uses it to construct a message that's a bit more helpful. The `assertCompile` function also ensures that the error message includes the name of the form being compiled.