### PR TITLE
Attempt to correlate line numbers in output with inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	$(LUA) test.lua
 
 luacheck:
-	luacheck fennel.lua
+	luacheck fennel.lua fennel
 
 count:
 	cloc fennel.lua

--- a/fennel
+++ b/fennel
@@ -11,14 +11,25 @@ Usage: fennel [FLAG] [FILE]
 
   With a single file argument, runs that file.]]
 
+local flags = {"--accurate"}
+local options = {}
+for _, flag in pairs(flags) do
+    for i = #arg, 1, -1 do
+        if arg[i] == flag then
+            table.remove(arg, i)
+            options[flag:gsub("[-][-]", "")] = true
+        end
+    end
+end
+
 if arg[1] == "--repl" or #arg == 0 then
     print("Welcome to fennel!")
     fennel.repl()
 elseif arg[1] == "--compile" then
     for i = 2, #arg do
         local f = assert(io.open(arg[i], "rb"))
-        local ok, val = pcall(fennel.compileString, f:read("*all"),
-                              {filename=arg[1]})
+        options.filename=arg[i]
+        local ok, val = pcall(fennel.compileString, f:read("*all"), options)
         print(val)
         if(not ok) then os.exit(1) end
         f:close()
@@ -27,7 +38,8 @@ elseif #arg == 1 then
     local filename = table.remove(arg, 1) -- let the script have remaining args
     local f = io.open(filename, "rb")
     if f then
-        local ok, val = pcall(fennel.eval, f:read("*all"), {filename=filename})
+        options.filename = filename
+        local ok, val = pcall(fennel.eval, f:read("*all"), options)
         print(val)
         if(not ok) then os.exit(1) end
         f:close()

--- a/fennel.lua
+++ b/fennel.lua
@@ -465,14 +465,14 @@ end
 
 -- Flatten a tree of indented Lua source code lines.
 -- Tab is what is used to indent a block. By default it is two spaces.
-local function flattenChunkPretty(chunk, tab, subChunk)
+local function flattenChunkPretty(chunk, tab, depth)
     if type(chunk) == 'string' then
         return chunk
     end
     tab = tab or '  ' -- 2 spaces
     for i = 1, #chunk do
-        local sub = flattenChunkPretty(chunk[i], tab, true)
-        if subChunk then sub = tab .. sub:gsub('\n', '\n' .. tab) end
+        local sub = flattenChunkPretty(chunk[i], tab, depth + 1)
+        if depth > 2 then sub = tab .. sub:gsub('\n', '\n' .. tab) end
         chunk[i] = sub
     end
     return table.concat(chunk, '\n')
@@ -508,7 +508,7 @@ local function flattenChunk(chunk, tab, accurate)
         end
         return table.concat(out, "\n")
     else
-        return flattenChunkPretty(chunk, tab)
+        return flattenChunkPretty(chunk, tab, 0)
     end
 end
 
@@ -522,7 +522,7 @@ local function exprs1(exprs)
 end
 
 local function emit(chunk, out, ast)
-    table.insert(chunk, {out, line= ast and ast.line})
+    table.insert(chunk, {out, line = ast and ast.line})
 end
 
 -- Compile sideffects for a chunk

--- a/fennel.lua
+++ b/fennel.lua
@@ -352,7 +352,7 @@ local function scopeInside(outer, inner)
     return false
 end
 
--- Assert a condition and emit a compile error with line numbers. The ast arg
+-- Assert a condition and raise a compile error with line numbers. The ast arg
 -- should be unmodified so that its first element is the form being called.
 local function assertCompile(condition, msg, ast)
     return assert(condition, string.format("Compile error in `%s' %s:%s: %s",
@@ -486,15 +486,19 @@ local function exprs1(exprs)
     return table.concat(t, ', ')
 end
 
+local function emit(chunk, out, ast)
+    table.insert(chunk, out)
+end
+
 -- Compile sideffects for a chunk
-local function keepSideEffects(exprs, chunk, start)
+local function keepSideEffects(exprs, chunk, start, ast)
     start = start or 1
     for j = start, #exprs do
         local se = exprs[j]
         if se.type == 'expression' then
-            chunk[#chunk + 1] = ('do local _ = %s end'):format(tostring(se))
+            emit(chunk, ('do local _ = %s end'):format(tostring(se)), ast)
         elseif se.type == 'statement' then
-            chunk[#chunk + 1] = tostring(se)
+            emit(chunk, tostring(se), ast)
         end
     end
 end
@@ -503,14 +507,14 @@ end
 -- targets for special forms. Also ensures a list expression
 -- has an accetable number of expressions if opts contains the
 -- "nval" option.
-local function handleCompileOpts(exprs, parent, opts)
+local function handleCompileOpts(exprs, parent, opts, ast)
     if opts.nval then
         local n = opts.nval
         if n ~= #exprs then
             local len = #exprs
             if len > n then
                 -- Drop extra
-                keepSideEffects(exprs, parent, n + 1)
+                keepSideEffects(exprs, parent, n + 1, ast)
                 for i = n, len do
                     exprs[i] = nil
                 end
@@ -523,10 +527,10 @@ local function handleCompileOpts(exprs, parent, opts)
         end
     end
     if opts.tail then
-        parent[#parent + 1] = ('return %s'):format(exprs1(exprs))
+        emit(parent, ('return %s'):format(exprs1(exprs)), ast)
     end
     if opts.target then
-        parent[#parent + 1] = ('%s = %s'):format(opts.target, exprs1(exprs))
+        emit(parent, ('%s = %s'):format(opts.target, exprs1(exprs)), ast)
     end
     if opts.tail or opts.target then
         -- Prevent statements and expression from being used twice if they
@@ -580,7 +584,7 @@ local function compile1(ast, scope, parent, opts)
             -- Unless the special form explicitely handles the target, tail, and nval properties,
             -- (indicated via the 'returned' flag, handle these options.
             if not exprs.returned then
-                exprs = handleCompileOpts(exprs, parent, opts)
+                exprs = handleCompileOpts(exprs, parent, opts, ast)
             elseif opts.tail or opts.target then
                 exprs = {}
             end
@@ -606,16 +610,16 @@ local function compile1(ast, scope, parent, opts)
                     end
                 else
                     -- Emit sub expression only for side effects
-                    keepSideEffects(subexprs, parent, 2)
+                    keepSideEffects(subexprs, parent, 2, ast[i])
                 end
             end
             local call = ('%s(%s)'):format(tostring(fcallee), exprs1(fargs))
-            exprs = handleCompileOpts({expr(call, 'statement')}, parent, opts)
+            exprs = handleCompileOpts({expr(call, 'statement')}, parent, opts, ast)
         end
     elseif isVarg(ast) then
-        exprs = handleCompileOpts({expr('...', 'varg')}, parent, opts)
+        exprs = handleCompileOpts({expr('...', 'varg')}, parent, opts, ast)
     elseif isSym(ast) then
-        exprs = handleCompileOpts({expr(stringMangle(ast[1], scope), 'sym')}, parent, opts)
+        exprs = handleCompileOpts({expr(stringMangle(ast[1], scope), 'sym')}, parent, opts, ast)
     elseif type(ast) == 'nil' or type(ast) == 'boolean' then
         exprs = handleCompileOpts({expr(tostring(ast), 'literal')}, parent, opts)
     elseif type(ast) == 'number' then
@@ -637,7 +641,7 @@ local function compile1(ast, scope, parent, opts)
             end
         end
         local tbl = '({' .. table.concat(buffer, ', ') ..'})'
-        exprs = handleCompileOpts({expr(tbl, 'expression')}, parent, opts)
+        exprs = handleCompileOpts({expr(tbl, 'expression')}, parent, opts, ast)
     else
         error('could not compile value of type ' .. type(ast))
     end
@@ -651,11 +655,11 @@ end
 local function destructure1(left, rightexprs, scope, parent, nonlocal)
     local setter = nonlocal and "%s = %s" or "local %s = %s"
     if isSym(left) then
-        parent[#parent + 1] = (setter):
-            format(stringMangle(left[1], scope), exprs1(rightexprs))
+        emit(parent, (setter):
+                 format(stringMangle(left[1], scope), exprs1(rightexprs)))
     elseif isTable(left) then -- table destructuring
         local s = gensym(scope)
-        parent[#parent + 1] = (setter):format(s, exprs1(rightexprs))
+        emit(parent, (setter):format(s, exprs1(rightexprs)))
         for i, v in ipairs(left) do
             local subexpr = expr(('%s[%d]'):format(s, i), 'expression')
             destructure1(v, {subexpr}, scope, parent, nonlocal)
@@ -672,8 +676,8 @@ local function destructure1(left, rightexprs, scope, parent, nonlocal)
             end
             table.insert(leftNames, symname)
         end
-        parent[#parent + 1] = (setter):
-            format(table.concat(leftNames, ", "), exprs1(rightexprs))
+        emit(parent, (setter):
+                 format(table.concat(leftNames, ", "), exprs1(rightexprs)))
         for _, pair in pairs(tables) do -- recurse if left-side tables found
             destructure1(pair[1], {pair[2]}, scope, parent, nonlocal)
         end
@@ -704,7 +708,7 @@ local function values(ast, scope, parent)
             end
         else
             -- Emit sub expression only for side effects
-            keepSideEffects(subexprs, parent, 2)
+            keepSideEffects(subexprs, parent, 2, ast)
         end
     end
     return exprs
@@ -751,18 +755,18 @@ local function doImpl(ast, scope, parent, opts, start, chunk, subScope)
                 retexprs[i] = expr(s, 'sym')
             end
             outerTarget = table.concat(syms, ', ')
-            parent[#parent + 1] = ('local %s'):format(outerTarget)
-            parent[#parent + 1] = 'do'
+            emit(parent, ('local %s'):format(outerTarget), ast)
+            emit(parent, 'do', ast)
         else
             -- We will use an IIFE for the do
             local fname = gensym(scope)
-            parent[#parent + 1] = ('local function %s()'):format(fname)
+            emit(parent, ('local function %s()'):format(fname), ast)
             retexprs = expr(fname .. '()', 'statement')
             outerTail = true
             outerTarget = nil
         end
     else
-        parent[#parent + 1] = 'do'
+        emit(parent, 'do', ast)
     end
     -- Compile the body
     if start > len then
@@ -781,12 +785,12 @@ local function doImpl(ast, scope, parent, opts, start, chunk, subScope)
             }
             local subexprs = compile1(ast[i], subScope, chunk, subopts)
             if i ~= len then
-                keepSideEffects(subexprs, parent)
+                keepSideEffects(subexprs, parent, nil, ast[i])
             end
         end
     end
-    parent[#parent + 1] = chunk
-    parent[#parent + 1] = 'end'
+    emit(parent, chunk, ast)
+    emit(parent, 'end', ast)
     return retexprs
 end
 
@@ -832,14 +836,14 @@ SPECIALS['fn'] = function(ast, scope, parent)
         })
     end
     if isLocalFn then
-        parent[#parent + 1] = ('local function %s(%s)')
-        :format(fnName, table.concat(argNameList, ', '))
+        emit(parent, ('local function %s(%s)')
+                 :format(fnName, table.concat(argNameList, ', ')), ast)
     else
-        parent[#parent + 1] = ('%s = function(%s)')
-        :format(fnName, table.concat(argNameList, ', '))
+        emit(parent, ('%s = function(%s)')
+                 :format(fnName, table.concat(argNameList, ', ')), ast)
     end
-    parent[#parent + 1] = fChunk
-    parent[#parent + 1] = 'end'
+    emit(parent, fChunk, ast)
+    emit(parent, 'end', ast)
     return fnName
 end
 
@@ -913,8 +917,8 @@ SPECIALS['special'] = function(ast, scope, parent)
     assertCompile(isSym(ast[2]), "expected symbol for name of special form", ast)
     local specname = tostring(ast[2])
     local spec = SPECIALS.fn(ast, scope, parent, {nval = 1})[1]
-    parent[#parent + 1] = ('_SCOPE.specials[%q] = %s'):format(
-        stringMangle(specname, scope), tostring(spec))
+    emit(parent, ('_SCOPE.specials[%q] = %s'):format(
+             stringMangle(specname, scope), tostring(spec)), ast)
 end
 
 SPECIALS['macro'] = function(ast, scope, parent, opts)
@@ -923,13 +927,12 @@ SPECIALS['macro'] = function(ast, scope, parent, opts)
     local mac = SPECIALS.fn(ast, scope, parent, opts)[1]
     local macroName = tostring(mac) -- the fn special form always returns a value
     local s = gensym(scope)
-    parent[#parent + 1] = ('local function %s(ast, scope, chunk, opts)'):format(s)
-    parent[#parent + 1] = {
-        'local unpack = table.unpack or unpack',
-        ('return _FNL.compile1(%s(unpack(ast, 2, ast.n)), scope, chunk, opts)'):format(macroName)
-    }
-    parent[#parent + 1] = 'end'
-    parent[#parent + 1] = ('_SCOPE.specials[%s] = %s'):format(macroName, s)
+    emit(parent, ('local function %s(ast, scope, chunk, opts)'):format(s), ast)
+    emit(parent, {'local unpack = table.unpack or unpack',
+                  ('return _FNL.compile1(%s(unpack(ast, 2, ast.n)), scope, chunk, opts)')
+                      :format(macroName)}, ast)
+    emit(parent, 'end', ast)
+    emit(parent, ('_SCOPE.specials[%s] = %s'):format(macroName, s), ast)
 end
 
 -- Wrapper for table access
@@ -971,7 +974,9 @@ SPECIALS['tset'] = function(ast, scope, parent)
         keys[#keys + 1] = tostring(key)
     end
     local value = compile1(ast[ast.n], scope, parent, {nval = 1})[1]
-    parent[#parent + 1] = ('%s[%s] = %s'):format(tostring(root), table.concat(keys, ']['), tostring(value))
+    emit(parent, ('%s[%s] = %s'):format(tostring(root),
+                                        table.concat(keys, ']['),
+                                        tostring(value)), ast)
 end
 
 -- The if special form behaves like the cond form in
@@ -1040,14 +1045,14 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
     end
 
     if wrapper == 'iife' then
-        parent[#parent + 1] = ('local function %s()'):format(tostring(s))
-        parent[#parent + 1] = buffer
-        parent[#parent + 1] = 'end'
+        emit(parent, ('local function %s()'):format(tostring(s)), ast)
+        emit(parent, buffer, ast)
+        emit(parent, 'end', ast)
         return expr(('%s()'):format(tostring(s)), 'statement')
     elseif wrapper == 'none' then
         -- Splice result right into code
         for i = 1, #buffer do
-            parent[#parent + 1] = buffer[i]
+            emit(parent, buffer[i], ast)
         end
         return {returned = true}
     end
@@ -1080,13 +1085,13 @@ SPECIALS['each'] = function(ast, scope, parent)
         assertCompile(isSym(v), 'expected iterator symbol', ast)
         table.insert(bindVars, stringMangle(v[1], scope))
     end
-    table.insert(parent, ('for %s in %s do'):format(
-                     table.concat(bindVars, ', '),
-                     tostring(compile1(iter, scope, parent, {nval = 1})[1])))
+    emit(parent, ('for %s in %s do'):format(
+             table.concat(bindVars, ', '),
+             tostring(compile1(iter, scope, parent, {nval = 1})[1])), ast)
     local chunk = {}
     compileDo(ast, scope, chunk, 3)
-    parent[#parent + 1] = chunk
-    parent[#parent + 1] = 'end'
+    emit(parent, chunk, ast)
+    emit(parent, 'end', ast)
 end
 
 -- (while condition body...) => []
@@ -1097,20 +1102,20 @@ SPECIALS['*while'] = function(ast, scope, parent)
     local subChunk = {}
     if len1 ~= len2 then
         -- Compound condition
-        parent[#parent + 1] = 'while true do'
+        emit(parent, 'while true do', ast)
         -- Move new compilation to subchunk
         for i = len1 + 1, len2 do
             subChunk[#subChunk + 1] = parent[i]
             parent[i] = nil
         end
-        parent[#parent + 1] = ('if %s then break end'):format(condition[1])
+        emit(parent, ('if %s then break end'):format(condition[1]), ast)
     else
         -- Simple condition
-        parent[#parent + 1] = 'while ' .. tostring(condition) .. ' do'
+        emit(parent, 'while ' .. tostring(condition) .. ' do', ast)
     end
     compileDo(ast, makeScope(scope), subChunk, 3)
-    parent[#parent + 1] = subChunk
-    parent[#parent + 1] = 'end'
+    emit(parent, subChunk, ast)
+    emit(parent, 'end', ast)
 end
 
 SPECIALS['for'] = function(ast, scope, parent)
@@ -1121,18 +1126,18 @@ SPECIALS['for'] = function(ast, scope, parent)
     for i = 1, math.min(#ranges, 3) do
         rangeArgs[i] = tostring(compile1(ranges[i], scope, parent, {nval = 1})[1])
     end
-    parent[#parent + 1] = ('for %s = %s do'):format(
-        stringMangle(bindingSym[1], scope),
-        table.concat(rangeArgs, ', '))
+    emit(parent, ('for %s = %s do'):format(
+             stringMangle(bindingSym[1], scope),
+             table.concat(rangeArgs, ', ')), ast)
     local chunk = {}
     compileDo(ast, scope, chunk, 3)
-    parent[#parent + 1] = chunk
-    parent[#parent + 1] = 'end'
+    emit(parent, chunk, ast)
+    emit(parent, 'end', ast)
 end
 
 -- Do we need this? Is there a more elegnant way to compile with break?
-SPECIALS['*break'] = function(_, _, parent)
-    parent[#parent + 1] = 'break'
+SPECIALS['*break'] = function(ast, _, parent)
+    emit(parent, 'break', ast)
 end
 
 local function defineArithmeticSpecial(name, unaryPrefix)
@@ -1202,7 +1207,7 @@ local function compile(ast, options)
     local chunk = {}
     local scope = options.scope or makeScope(GLOBAL_SCOPE)
     local exprs = compile1(ast, scope, chunk, {tail = true})
-    keepSideEffects(exprs, chunk)
+    keepSideEffects(exprs, chunk, nil, ast)
     return flattenChunk(chunk, options.indent)
 end
 
@@ -1219,7 +1224,7 @@ local function compileStream(strm, options)
         local exprs = compile1(vals[i], scope, chunk, {
             tail = i == #vals
         })
-        keepSideEffects(exprs, chunk)
+        keepSideEffects(exprs, chunk, nil, vals[i])
     end
     return flattenChunk(chunk, options.indent)
 end

--- a/fennel.lua
+++ b/fennel.lua
@@ -1309,7 +1309,7 @@ local function repl(givenOptions)
         local ok, parseok, x = pcall(read)
         if ok then
             if not parseok then break end -- eof
-            local compileOk, luaSource = pcall(compile, x)
+            local compileOk, luaSource = pcall(compile, x, options)
             if not compileOk then
                 -- Compiler error
                 clearstream()


### PR DESCRIPTION
A rough first pass; needs a lot more testing but appears to not blow things up too badly.

Currently only active when you pass `{accurate=true}` as options to `compile` or `eval`.

Interested in hearing what you think. It turned out easier than I expected.