### PR TITLE
Require

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,29 @@ Eventually, I also hope to add optional source maps, either embedded in the comm
 
 ## Lua API
 
-The fennel module exports the following functions:
+The fennel module exports the following functions. Most functions take
+an `indent` function to override how to indent the compiled Lua output
+or an `accurate` function to ignore indentation and attempt to make
+the lines in the output code match up with the lines in the input code.
 
 Start a configurable repl.
 ```lua
 fennel.repl([options])
 ```
+Takes these additional options:
+
+* `read`, `write`, and `flush`: replacements for equivalents from `io` table.
+* `env`: an environment table in which to run the code; see the Lua manual.
 
 Evaulate a string of Fennel.
 ```lua
 local result = fennel.eval(str[, options])
 ```
+
+Takes these additional options:
+
+* `env`: same as above.
+* `filename`: override the filename that Lua thinks the code came from.
 
 Evaluate a file of Fennel.
 ```lua

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Evaulate a string of Fennel.
 local result = fennel.eval(str[, options])
 ```
 
+Evaluate a file of Fennel.
+```lua
+local result = fennel.dofile(filename)
+```
+
 Compile a string into Lua. Can throw errors.
 ```lua
 local lua = fennel.compileString(str[, options])

--- a/fennel
+++ b/fennel
@@ -34,18 +34,9 @@ elseif arg[1] == "--compile" then
         if(not ok) then os.exit(1) end
         f:close()
     end
-elseif #arg == 1 then
+elseif #arg == 1 and arg[1] ~= "--help" then
     local filename = table.remove(arg, 1) -- let the script have remaining args
-    local f = io.open(filename, "rb")
-    if f then
-        options.filename = filename
-        local ok, val = pcall(fennel.eval, f:read("*all"), options)
-        print(val)
-        if(not ok) then os.exit(1) end
-        f:close()
-    else
-        print(help)
-    end
+    fennel.dofile(filename)
 else
     print(help)
 end

--- a/fennel
+++ b/fennel
@@ -36,7 +36,11 @@ elseif arg[1] == "--compile" then
     end
 elseif #arg == 1 and arg[1] ~= "--help" then
     local filename = table.remove(arg, 1) -- let the script have remaining args
-    fennel.dofile(filename)
+    local ok, val = pcall(fennel.dofile, filename)
+    if(not ok) then
+        print(val)
+        os.exit(1)
+    end
 else
     print(help)
 end

--- a/fennel.lua
+++ b/fennel.lua
@@ -1323,6 +1323,12 @@ local function eval(str, options)
     return loader()
 end
 
+local function dofile_fennel(filename)
+    local f = assert(io.open(filename, "rb"))
+    eval(f:read("*all"), { filename = filename, accurate = true })
+    f:close()
+end
+
 -- Implements a configurable repl
 local function repl(givenOptions)
     local options = {
@@ -1398,7 +1404,8 @@ local module = {
     scope = makeScope,
     gensym = gensym,
     eval = eval,
-    repl = repl
+    repl = repl,
+    dofile = dofile_fennel,
 }
 
 SPECIALS['eval-compiler'] = function(ast, scope, parent)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1336,7 +1336,6 @@ local function repl(givenOptions)
         read = io.read,
         write = io.write,
         flush = io.flush,
-        print = print,
     }
     for k,v in pairs(givenOptions or {}) do
         options[k] = v
@@ -1360,24 +1359,26 @@ local function repl(givenOptions)
             if not compileOk then
                 -- Compiler error
                 clearstream()
-                options.print('Compile error: ' .. luaSource)
+                options.write('Compile error: ' .. luaSource .. '\n')
             else
                 local luacompileok, loader = pcall(loadCode, luaSource, env)
                 if not luacompileok then
                     clearstream()
-                    options.print('Bad code generated - likely a bug with the compiler:')
-                    options.print('--- Generated Lua Start ---')
-                    options.print(luaSource)
-                    options.print('--- Generated Lua End ---')
-                    options.print('Compiler error: ' .. loader)
+                    options.write('Bad code generated - likely a bug with the compiler:\n')
+                    options.write('--- Generated Lua Start ---\n')
+                    options.write(luaSource .. '\n')
+                    options.write('--- Generated Lua End ---\n')
+                    options.write('Compiler error: ' .. tostring(loader) .. '\n')
                 else
                     local loadok, ret = xpcall(function () return tpack(loader()) end,
                         function (runtimeErr)
                             -- We can do more sophisticated display here
-                            options.print(runtimeErr)
+                            options.write(tostring(runtimeErr) .. '\n')
                         end)
                     if loadok then
-                        options.print(unpack(ret, 1, ret.n))
+                        for i = 1, ret.n do ret[i] = tostring(ret[i]) end
+                        options.write(unpack(ret, 1, ret.n))
+                        options.write('\n')
                         env._ = ret[1]
                         env.__ = ret
                     end

--- a/fennel.lua
+++ b/fennel.lua
@@ -1325,8 +1325,10 @@ end
 
 local function dofile_fennel(filename)
     local f = assert(io.open(filename, "rb"))
-    eval(f:read("*all"), { filename = filename, accurate = true })
+    local vals = tpack(eval(f:read("*all"), { filename = filename,
+                                              accurate = true }))
     f:close()
+    return unpack(vals)
 end
 
 -- Implements a configurable repl

--- a/fennel.lua
+++ b/fennel.lua
@@ -1409,7 +1409,24 @@ local module = {
     eval = eval,
     repl = repl,
     dofile = dofile_fennel,
+    path = "./?.fnl",
 }
+
+-- This will allow regular `require` to work with Fennel:
+-- table.insert(package.loaders, fennel.searcher)
+module.searcher = function(modulename)
+    modulename = modulename:gsub("%.", "/")
+    for path in string.gmatch(module.path..";", "([^;]*);") do
+        local filename = path:gsub("%?", modulename)
+        local file = io.open(filename, "rb")
+        if(file) then
+            file:close()
+            return function()
+                return dofile_fennel(filename)
+            end
+        end
+    end
+end
 
 SPECIALS['eval-compiler'] = function(ast, scope, parent)
     local oldFirst = ast[1]


### PR DESCRIPTION
I've added a few features on this branch. First of all I think `fennel.dofile` is pretty nice to have; it just moves some stuff out of the wrapper executable so others can re-use it.

I started to add a `fennel.require` script, but then I looked into how Lua implements regular `require` and it's designed to be extensible by adding new entries into the `package.loaders` table. So I gave that a shot instead. This patch implements a `fennel.searcher` function which you can put there to make regular `require` work transparently on Fennel code:

```lisp
>> (set fennel (require "fennel"))
>> (table.insert package.loaders fennel.searcher)
>> (require "hey.in") ; runs (fennel.dofile "hey/in.fnl") on the first run and caches for subsequent runs
188.4
table: 0x563bf92663f0
```

This seems pretty nice, but I'm not 100% sure we want Fennel modules to be able to shadow Lua modules? I guess there are pros and cons. We could also just implement our own distinct `fennel.require` function which doesn't touch the built-in Lua `package` table at all and implemented its own version of `package.loaded`. I'm happy to implement that if it's what you prefer.

Thoughts?