### PR TITLE
Fix (some) macros

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -958,7 +958,7 @@ SPECIALS['special'] = function(ast, scope, parent)
     assertCompile(isSym(ast[2]), "expected symbol for name of special form", ast)
     local specname = tostring(ast[2])
     local spec = SPECIALS.fn(ast, scope, parent, {nval = 1})[1]
-    emit(parent, ('_SCOPE.specials[%q] = %s'):format(
+    emit(parent, ('_SPECIALS[\'%q\'] = %s'):format(
              stringMangle(specname, scope), tostring(spec)), ast)
 end
 
@@ -973,7 +973,7 @@ SPECIALS['macro'] = function(ast, scope, parent, opts)
                   ('return _FNL.compile1(%s(unpack(ast, 2, ast.n)), scope, chunk, opts)')
                       :format(macroName)}, ast)
     emit(parent, 'end', ast)
-    emit(parent, ('_SCOPE.specials[\'%s\'] = %s'):format(macroName, s), ast)
+    emit(parent, ('_SPECIALS[\'%s\'] = %s'):format(macroName, s), ast)
 end
 
 -- Wrapper for table access
@@ -1387,7 +1387,7 @@ local function repl(givenOptions)
                 end
             end
         else
-            options.print('Parse error: ' .. parseok)
+            options.write('Parse error: ' .. tostring(parseok) .. '\n')
             clearstream()
         end
     end
@@ -1438,7 +1438,8 @@ SPECIALS['eval-compiler'] = function(ast, scope, parent)
         _SCOPE = COMPILER_SCOPE,
         _CHUNK = parent,
         _AST = ast,
-        _IS_COMPILER = true
+        _IS_COMPILER = true,
+        _SPECIALS = SPECIALS,
     }, { __index = _ENV or _G })
     local loader = loadCode(luaSource, env)
     loader()


### PR DESCRIPTION
I found a few bugs in the `macro` implementation which this PR fixes, but it doesn't go all the way towards fixing it. There's still a problem where `COMPILER_SCOPE` is wrapped in a subscope, so `emit(parent, ('_SCOPE.specials[\'%s\'] = %s'):format(macroName, s), ast)` sets a `specials` which is just discarded when the form is done.

I'm not sure how to ensure that the top-level specials table is the one that gets the new entry, but this should at least get it closer to working.