### PR TITLE
Treat nil as a self-evaluating symbol in the AST instead of actual nil.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1258,7 +1258,6 @@ defineArithmeticSpecial('and')
 local function defineComparatorSpecial(name, realop)
     local op = realop or name
     SPECIALS[name] = function(ast, scope, parent)
-        if (#ast ~= 3) then print(ast) end
         assertCompile(#ast == 3, 'expected two arguments', ast)
         local lhs = compile1(ast[2], scope, parent, {nval = 1})
         local rhs = compile1(ast[3], scope, parent, {nval = 1})

--- a/test.lua
+++ b/test.lua
@@ -166,9 +166,9 @@ fennel.eval([[(eval-compiler
       (list (sym "fn") args ...)))
   (special reverse-it [ast scope parent opts]
     (tset ast 1 "do")
-    (for [i 2 (math.ceil (/ ast.n 2))]
-      (let [a (. ast i) b (. ast (- ast.n (- i 2)))]
-        (tset ast (- ast.n (- i 2)) a)
+    (for [i 2 (math.ceil (/ (# ast) 2))]
+      (let [a (. ast i) b (. ast (- (# ast) (- i 2)))]
+        (tset ast (- (# ast) (- i 2)) a)
         (tset ast i b)))
     (_SPECIALS.do ast scope parent opts))
 )]])

--- a/test.lua
+++ b/test.lua
@@ -90,6 +90,8 @@ local cases = {
         ["(let [my-tbl {} k :key] (tset my-tbl k :val) my-tbl.key)"]="val",
         -- functions inside each
         ["(do (each [_ ((fn [] (pairs [1])))] (set i 1)) i)"]=1,
+        -- let with nil value
+        ["(let [x 3 y nil z 293] z)"]=293,
         -- nested let inside loop
         ["(do (for [_ 1 3] (let [] (table.concat []) (set a 33))) a)"]=33,
     },


### PR DESCRIPTION
Given that Lua tables cannot store nil and lisp code is stored in data
structures, we either must cheat on tables and try to find a way to
make them store nil, or cheat on nil and find a way to store it in tables.

I believe the second approach is simpler since the symbol `nil`
naturally evaluates to nil; the only hiccup is that it must be
disallowed from being used as the name of a local. There are only two
places function parameters are introduced (destructuring and fn) so
catching those two is pretty straightforward.

I believe this would allow us to clean up a lot of AST-using code
since we could now trust Lua's built-in length operator to do the
right thing and stop tracking the .n field of parsed lists. Having to
ensure the correct value in the .n field was one surprising thing I
found quite error-prone when writing my own macros.

Fixes #35.