### PR TITLE
Replacement require-macros form

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ Takes these additional options:
 ### Evaluate a file of Fennel
 
 ```lua
-local result = fennel.dofile(filename)
+local result = fennel.dofile(filename[, options])
 ```
+
+* `env`: same as above.
 
 ### Use Lua's built-in require function
 
@@ -151,7 +153,7 @@ local lua = fennel.compile(ast)
 
 ## Try it
 
-Clone the repository, and run `lua fennel --repl` to quickly start a repl.
+Clone the repository, and run `./fennel --repl` to quickly start a repl.
 
 ## Install with Luarocks
 
@@ -176,6 +178,7 @@ fennel --compile myscript.fnl > myscript.lua
 ## Resources
 
 * [Emacs support](https://gitlab.com/technomancy/fennel-mode)
+* [Wiki](https://github.com/bakpakin/Fennel/wiki)
 * Build: [![CircleCI](https://circleci.com/gh/bakpakin/Fennel.svg?style=svg)](https://circleci.com/gh/bakpakin/Fennel)
 
 ## License

--- a/test-macros.fnl
+++ b/test-macros.fnl
@@ -1,0 +1,11 @@
+;; this module is loaded by the test suite, but these are handy macros to
+;; have around so feel free to steal them for your own projects.
+{"->" (fn [val ...]
+        (each [_ elt (pairs [...])]
+          (table.insert elt 2 val)
+          (set elt.n (+ 1 elt.n))
+          (set val elt))
+        val)
+ :defn (fn [name args ...]
+         (list (sym "set") name
+               (list (sym "fn") args ...)))}


### PR DESCRIPTION
After some discussion on the `#fennel` freenode channel it was
observed that the current `macro` and `special` calls could be
problematic on larger codebases because they are global.

I started thinking about what a macro system would look like which
used the existing module system and didn't affect global compiler
state, and I came up with the `require-macros` form.

```lisp
;; main.fnl
(require-macros "mymacros")

(defn add-seven-then-multiply-by-a-hundred [x]
  (-> x (+ 7) (* 100)))

(print add-seven-then-multiply-by-a-hundred 93)
```

```lisp
;; mymacros.fnl
{"->" (fn [val ...]
        (each [_ elt (pairs [...])]
          (table.insert elt 2 val)
          (set elt.n (+ 1 elt.n))
          (set val elt))
        val)
 "defn" (fn [name args ...]
          (list (sym "set") name
                (list (sym "fn") args ...)))}
```

This allows you to import macros just for the scope of a single file
(or if you really want to, for the scope of a single function). The
`mymacros.fnl` file would be loaded in the same kind context as
`eval-compiler` currently works.

I *think* it's comprehensive enough that it could replace the existing
`macro`, `special`, and `eval-compiler` forms, but I'll admit I
haven't thought thru the implications of that fully. Maybe `special`
and `eval-compiler` are still needed in some contexts?

What do you think?