### PR TITLE
Add fennelview for pretty-printing repl results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,14 @@ fennel.repl([options])
 Takes these additional options:
 
 * `read`, `write`, and `flush`: replacements for equivalents from `io` table.
-* `pp`: a pretty-printer function to apply on values; defaults to `tostring`.
+* `pp`: a pretty-printer function to apply on values.
 * `env`: an environment table in which to run the code; see the Lua manual.
+
+The pretty-printer defaults to loading `fennelview.fnl` if present and
+falls back to `tostring` otherwise. `fennelview.fnl` will produce
+output that can be fed back into Fennel (other than functions,
+coroutines, etc) but you can use a 3rd-party pretty-printer that
+produces output in Lua format if you prefer.
 
 ### Evaulate a string of Fennel
 
@@ -157,16 +163,7 @@ local lua = fennel.compile(ast)
 
 Clone the repository, and run `./fennel --repl` to quickly start a repl.
 
-The repl will load the file `~/.fennelrc` on startup if it exists. If
-you'd like to install a pretty-printer for the repl (recommended), put
-this in that file:
-
-```lisp
-(set options.pp (dofile "/path/to/inspect.lua"))
-```
-
-You can point it at a pretty-printing function of your choice; here we
-use [inspect.lua](https://github.com/kikito/inspect.lua).
+The repl will load the file `~/.fennelrc` on startup if it exists.
 
 ## Install with Luarocks
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -1336,12 +1336,15 @@ end
 
 -- Implements a configurable repl
 local function repl(givenOptions)
+    local ppok, pp = pcall(dofile_fennel, "fennelview.fnl", givenOptions)
+    if not ppok then print("err", pp) pp = tostring end
+
     local options = {
         prompt = '>> ',
         read = io.read,
         write = io.write,
         flush = io.flush,
-        pp = tostring,
+        pp = pp,
     }
     for k,v in pairs(givenOptions or {}) do
         options[k] = v

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -1,0 +1,154 @@
+;; A pretty-printer that outputs tables in Fennel syntax.
+;; Loosely based on inspect.lua: http://github.com/kikito/inspect.lua
+
+(local quote (fn [str] (.. '"' (: str :gsub '"' '\\"') '"')))
+
+(local short-control-char-escapes
+       {"\a" "\\a" "\b" "\\b" "\f" "\\f" "\n" "\\n"
+        "\r" "\\r" "\t" "\\t" "\v" "\\v"})
+
+(local long-control-char-esapes {})
+
+(for [i 0 31]
+  (let [ch (string.char i)]
+    (when (not (. short-control-char-escapes ch))
+      (tset short-control-char-escapes ch (.. "\\" i))
+      (tset long-control-char-esapes ch (: "\\%03d" :format i)))))
+
+(local escape (fn [str]
+                (let [str (: str :gsub "\\" "\\\\")
+                      str (: str :gsub "(%c)%f[0-9]" long-control-char-esapes)]
+                  (: str :gsub "%c" short-control-char-escapes))))
+
+(local sequence-key? (fn [k len]
+                       (and (= (type k) "number")
+                            (<= 1 k)
+                            (<= k len)
+                            (= (math.floor k) k))))
+
+(local type-order {:number 1 :boolean 2 :string 3 :table 4
+                   :function 5 :userdata 6 :thread 7})
+
+(local sort-keys (fn [a b]
+                   (let [ta (type a) tb (type b)]
+                     (if (and (= ta tb) (~= ta "boolean")
+                              (or (= ta "string") (= ta "number")))
+                         (< a b)
+                         (let [dta (. type-order a)
+                               dtb (. type-order b)]
+                           (if (and dta dtb)
+                               (< dta dtb)
+                               dta true
+                               dtb false
+                               :else (< ta tb)))))))
+
+(local get-sequence-length
+       (fn [t]
+         (let [len 1]
+           (each [i (ipairs t)] (set len i))
+           len)))
+
+(local get-nonsequential-keys
+       (fn [t]
+         (let [keys {}
+               sequence-length (get-sequence-length t)]
+           (each [k (pairs t)]
+             (when (not (sequence-key? k sequence-length))
+               (table.insert keys k)))
+           (table.sort keys sort-keys)
+           (values keys sequence-length))))
+
+(local count-table-appearances
+       (fn recur [t appearances]
+         (if (= (type t) "table")
+             (when (not (. appearances t))
+               (tset appearances t 1)
+               (each [k v (pairs t)]
+                 (recur k appearances)
+                 (recur v appearances)))
+             (when (= t t) ; no nans please
+               (tset appearances t (+ (or (. appearances t) 0) 1))))
+         appearances))
+
+
+
+(local put-value nil) ; mutual recursion going on; defined below
+
+(local puts (fn [self ...]
+              (each [_ v (ipairs [...])]
+                (table.insert self.buffer v))))
+
+(local tabify (fn [self] (puts self "\n" (: self.indent :rep self.level))))
+
+(local already-visited? (fn [self v] (~= (. self.ids v) nil)))
+
+(local get-id (fn [self v]
+                (let [id (. self.ids v)]
+                  (when (not id)
+                    (let [tv (type v)]
+                      (set id (+ (or (. self.max-ids tv) 0) 1))
+                      (tset self.max-ids tv id)
+                      (tset self.ids v id)))
+                  (tostring id))))
+
+(local put-sequential-table (fn [self t length]
+                              (puts self "[")
+                              (set self.level (+ self.level 1))
+                              (for [i 1 length]
+                                (puts self " ")
+                                (put-value self (. t i)))
+                              (set self.level (- self.level 1))
+                              (puts self " ]")))
+
+(local put-key (fn [self k]
+                 (if (and (= (type k) "string") (not (: k :find "%W")))
+                     (puts self ":" k)
+                     (put-value self k))))
+
+(local put-kv-table (fn [self t]
+                      (puts self "{")
+                      (set self.level (+ self.level 1))
+                      (each [k v (pairs t)]
+                        (tabify self)
+                        (put-key self k)
+                        (puts self " ")
+                        (put-value self v))
+                      (set self.level (- self.level 1))
+                      (tabify self)
+                      (puts self "}")))
+
+(local put-table (fn [self t]
+                   (if (already-visited? self t)
+                       (puts self "#<table " (get-id self t) ">")
+                       (>= self.level self.depth)
+                       (puts self "{...}")
+                       :else
+                       (let [(non-seq-keys length) (get-nonsequential-keys t)]
+                         (if (> (. self.appearances t) 1)
+                             (puts self "#<" (get-id self t) ">")
+                             (= (# non-seq-keys) 0)
+                             (put-sequential-table self t length)
+                             :else
+                             (put-kv-table self t))))))
+
+(set put-value (fn [self v]
+                 (let [tv (type v)]
+                   (if (= tv "string")
+                       (puts self (quote (escape v)))
+                       (or (= tv "number") (= tv "boolean") (= tv "nil"))
+                       (puts self (tostring v))
+                       (= tv "table")
+                       (put-table self v)
+                       :else
+                       (puts self "#<" tv " " (get-id self v) ">")))))
+
+
+
+(fn [root options]
+  (let [options (or options {})
+        inspector {:appearances (count-table-appearances root {})
+                   :depth (or options.depth 128)
+                   :level 0 :buffer {} :ids {} :max-ids {}
+                   :indent (or options.indent "  ")}]
+    (put-value inspector root)
+    (table.concat inspector.buffer)))

--- a/generate.fnl
+++ b/generate.fnl
@@ -1,0 +1,48 @@
+;; A general-purpose function for generating random values.
+
+(local generate nil)
+
+(local random-char
+       (fn []
+         (if (> (math.random) 0.9)
+             (string.char (+ 48 (math.random 10)))
+             (> (math.random) 0.5)
+             (string.char (+ 97 (math.random 26)))
+             (> (math.random) 0.5)
+             (string.char (+ 65 (math.random 26)))
+             (> (math.random) 0.5)
+             (string.char (+ 32 (math.random 15)))
+             :else
+             (string.char (+ 58 (math.random 5))))))
+
+(local generators {:number (fn [] ; weighted towards mid-range integers
+                             (if (> (math.random) 0.9)
+                                 (let [x (math.random math.huge)]
+                                   (math.floor (- x (/ x 2))))
+                                 (> (math.random) 0.2)
+                                 (math.floor (math.random 2048))
+                                 :else (math.random)))
+                   :string (fn []
+                             (let [s ""]
+                               (for [_ 1 (math.random 16)]
+                                 (set s (.. s (random-char))))
+                               s))
+                   :table (fn [table-chance]
+                            (let [t {} k nil]
+                              (for [_ 1 (math.random 16)]
+                                ;; no nans plz
+                                (set k (generate 0.9))
+                                (*while (~= k k) (set k (generate 0.9)))
+                                (tset t k (generate (* table-chance 1.5))))
+                              t))
+                   :boolean (fn [] (> (math.random) 0.5))})
+
+(set generate
+     (fn [table-chance]
+       (set table-chance (or table-chance 0.5))
+       (if (> (math.random) 0.5) (generators.number)
+           (> (math.random) 0.5) (generators.string)
+           (> (math.random) table-chance) (generators.table table-chance)
+           :else (generators.boolean))))
+
+generate


### PR DESCRIPTION
This change uses `pcall` to attempt to load `fennelview.fnl` as the default pretty-printer for the repl, but it safely falls back to `tostring` if it's not found. This allows `fennel.lua` to continue to be used as a single-file library.

I added generative testing, but I'm not sure it's quite ready to merge. Certain seeds will produce strings which crash the parser (`SEED=1521395122`, `SEED=1521395046`) and other seeds can cause infinite loops in `fennelview`. (`SEED=1521395257`)

So I'll try to get those sorted out before merging.