### PR TITLE
Opt-in local mutability and separate global setter

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ local lua = fennel.compile(ast)
 
 #### Fibonacci sequence
 ```
-(set fib (fn [n] (or (and (> n 1)
-                          (+ (fib (- n 1))
-                             (fib (- n 2))))
-                     1)))
+(local fib (fn [n] (or (and (> n 1)
+                            (+ (fib (- n 1))
+                               (fib (- n 2))))
+                       1)))
 
 (print (fib 10))
 ```
@@ -184,6 +184,8 @@ To compile a file:
 ```sh
 fennel --compile myscript.fnl > myscript.lua
 ```
+
+When given a file without a flag, it will simply load and run the file.
 
 ## Resources
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -1015,12 +1015,16 @@ SPECIALS['set!'] = function(ast, scope, parent)
     destructure(ast[2], ast[3], scope, parent, true)
 end
 
+local function inScope(name, scope)
+    return scope.manglings[name] or scope.parent and inScope(name, scope.parent)
+end
+
 SPECIALS['set'] = function(ast, scope, parent)
     assertCompile(#ast == 3, "expected name and value", ast)
     local target = ast[2][1]
     local parts = isMultiSym(target)
     if parts then target = parts[1] end
-    assertCompile(scope.manglings[target],
+    assertCompile(inScope(target, scope),
                   ("tried to set %s which isn't in scope; use set! for globals")
                       :format(target), ast)
     destructure(ast[2], ast[3], scope, parent, true)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1010,8 +1010,19 @@ SPECIALS['.'] = function(ast, scope, parent)
     return ('%s[%s]'):format(tostring(lhs[1]), tostring(rhs[1]))
 end
 
+SPECIALS['set!'] = function(ast, scope, parent)
+    assertCompile(#ast == 3, "expected name and value", ast)
+    destructure(ast[2], ast[3], scope, parent, true)
+end
+
 SPECIALS['set'] = function(ast, scope, parent)
     assertCompile(#ast == 3, "expected name and value", ast)
+    local target = ast[2][1]
+    local parts = isMultiSym(target)
+    if parts then target = parts[1] end
+    assertCompile(scope.manglings[target],
+                  ("tried to set %s which isn't in scope; use set! for globals")
+                      :format(target), ast)
     destructure(ast[2], ast[3], scope, parent, true)
 end
 
@@ -1370,7 +1381,7 @@ end
 -- Implements a configurable repl
 local function repl(givenOptions)
     local ppok, pp = pcall(dofile_fennel, "fennelview.fnl", givenOptions)
-    if not ppok then print("err", pp) pp = tostring end
+    if not ppok then pp = tostring end
 
     local options = {
         prompt = '>> ',

--- a/fennel.lua
+++ b/fennel.lua
@@ -337,6 +337,7 @@ local function makeScope(parent)
         specials = setmetatable({}, {
             __index = parent and parent.specials
         }),
+        vars = {}, -- whitelist for whether set works on a local
         parent = parent,
         vararg = parent and parent.vararg,
         depth = parent and ((parent.depth or 0) + 1) or 0
@@ -1010,13 +1011,22 @@ SPECIALS['.'] = function(ast, scope, parent)
     return ('%s[%s]'):format(tostring(lhs[1]), tostring(rhs[1]))
 end
 
-SPECIALS['set!'] = function(ast, scope, parent)
+local function inScope(name, scope)
+    return scope.manglings[name] or scope.parent and inScope(name, scope.parent)
+end
+
+SPECIALS['global'] = function(ast, scope, parent)
     assertCompile(#ast == 3, "expected name and value", ast)
+    local target = ast[2][1]
+    local parts = isMultiSym(target)
+    if parts then target = parts[1] end
+    assertCompile(not inScope(target, scope),
+                  ("tried to set local %s"):format(tostring(target)), ast)
     destructure(ast[2], ast[3], scope, parent, true)
 end
 
-local function inScope(name, scope)
-    return scope.manglings[name] or scope.parent and inScope(name, scope.parent)
+local function isVar(name, scope)
+    return scope.vars[name] or scope.parent and isVar(name, scope.parent)
 end
 
 SPECIALS['set'] = function(ast, scope, parent)
@@ -1024,14 +1034,27 @@ SPECIALS['set'] = function(ast, scope, parent)
     local target = ast[2][1]
     local parts = isMultiSym(target)
     if parts then target = parts[1] end
-    assertCompile(inScope(target, scope),
-                  ("tried to set %s which isn't in scope; use set! for globals")
-                      :format(target), ast)
+    assertCompile(isVar(target, scope) or parts,
+                  ("expected local var %s"):format(target), ast)
     destructure(ast[2], ast[3], scope, parent, true)
 end
 
 SPECIALS['local'] = function(ast, scope, parent)
     assertCompile(#ast == 3, "expected name and value", ast)
+    destructure(ast[2], ast[3], scope, parent, false)
+end
+
+local function scopeVars(v, scope)
+    if isSym(v) then
+        scope.vars[v[1]] = true
+    else
+        for _, v2 in ipairs(v) do scopeVars(v2, scope) end
+    end
+end
+
+SPECIALS['var'] = function(ast, scope, parent)
+    assertCompile(#ast == 3, "expected name and value", ast)
+    scopeVars(ast[2], scope)
     destructure(ast[2], ast[3], scope, parent, false)
 end
 

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -44,9 +44,9 @@
 
 (local get-sequence-length
        (fn [t]
-         (let [len 1]
-           (each [i (ipairs t)] (set len i))
-           len)))
+         (var len 1)
+         (each [i (ipairs t)] (set len i))
+         len))
 
 (local get-nonsequential-keys
        (fn [t]
@@ -72,7 +72,7 @@
 
 
 
-(local put-value nil) ; mutual recursion going on; defined below
+(var put-value nil) ; mutual recursion going on; defined below
 
 (local puts (fn [self ...]
               (each [_ v (ipairs [...])]
@@ -83,13 +83,13 @@
 (local already-visited? (fn [self v] (~= (. self.ids v) nil)))
 
 (local get-id (fn [self v]
-                (let [id (. self.ids v)]
-                  (when (not id)
-                    (let [tv (type v)]
-                      (set id (+ (or (. self.max-ids tv) 0) 1))
-                      (tset self.max-ids tv id)
-                      (tset self.ids v id)))
-                  (tostring id))))
+                (var id (. self.ids v))
+                (when (not id)
+                  (let [tv (type v)]
+                    (set id (+ (or (. self.max-ids tv) 0) 1))
+                    (tset self.max-ids tv id)
+                    (tset self.ids v id)))
+                (tostring id)))
 
 (local put-sequential-table (fn [self t length]
                               (puts self "[")
@@ -131,16 +131,16 @@
                              :else
                              (put-kv-table self t))))))
 
-(set! put-value (fn [self v]
-                  (let [tv (type v)]
-                    (if (= tv "string")
-                        (puts self (quote (escape v)))
-                        (or (= tv "number") (= tv "boolean") (= tv "nil"))
-                        (puts self (tostring v))
-                        (= tv "table")
-                        (put-table self v)
-                        :else
-                        (puts self "#<" tv " " (get-id self v) ">")))))
+(set put-value (fn [self v]
+                 (let [tv (type v)]
+                   (if (= tv "string")
+                       (puts self (quote (escape v)))
+                       (or (= tv "number") (= tv "boolean") (= tv "nil"))
+                       (puts self (tostring v))
+                       (= tv "table")
+                       (put-table self v)
+                       :else
+                       (puts self "#<" tv " " (get-id self v) ">")))))
 
 
 

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -66,7 +66,7 @@
                (each [k v (pairs t)]
                  (recur k appearances)
                  (recur v appearances)))
-             (when (= t t) ; no nans please
+             (when (and t (= t t)) ; no nans please
                (tset appearances t (+ (or (. appearances t) 0) 1))))
          appearances))
 

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -123,9 +123,10 @@
                        (>= self.level self.depth)
                        (puts self "{...}")
                        :else
-                       (let [(non-seq-keys length) (get-nonsequential-keys t)]
+                       (let [(non-seq-keys length) (get-nonsequential-keys t)
+                             id (get-id self t)]
                          (if (> (. self.appearances t) 1)
-                             (puts self "#<" (get-id self t) ">")
+                             (puts self "#<" id ">")
                              (= (# non-seq-keys) 0)
                              (put-sequential-table self t length)
                              :else

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -131,16 +131,16 @@
                              :else
                              (put-kv-table self t))))))
 
-(set put-value (fn [self v]
-                 (let [tv (type v)]
-                   (if (= tv "string")
-                       (puts self (quote (escape v)))
-                       (or (= tv "number") (= tv "boolean") (= tv "nil"))
-                       (puts self (tostring v))
-                       (= tv "table")
-                       (put-table self v)
-                       :else
-                       (puts self "#<" tv " " (get-id self v) ">")))))
+(set! put-value (fn [self v]
+                  (let [tv (type v)]
+                    (if (= tv "string")
+                        (puts self (quote (escape v)))
+                        (or (= tv "number") (= tv "boolean") (= tv "nil"))
+                        (puts self (tostring v))
+                        (= tv "table")
+                        (put-table self v)
+                        :else
+                        (puts self "#<" tv " " (get-id self v) ">")))))
 
 
 

--- a/generate.fnl
+++ b/generate.fnl
@@ -1,6 +1,6 @@
 ;; A general-purpose function for generating random values.
 
-(local generate nil)
+(var generate nil)
 
 (local random-char
        (fn []
@@ -23,12 +23,13 @@
                                  (math.floor (math.random 2048))
                                  :else (math.random)))
                    :string (fn []
-                             (let [s ""]
-                               (for [_ 1 (math.random 16)]
-                                 (set s (.. s (random-char))))
-                               s))
+                             (var s "")
+                             (for [_ 1 (math.random 16)]
+                               (set s (.. s (random-char))))
+                             s)
                    :table (fn [table-chance]
-                            (let [t {} k nil]
+                            (let [t {}]
+                              (var k nil)
                               (for [_ 1 (math.random 16)]
                                 ;; no nans plz
                                 (set k (generate 0.9))
@@ -37,12 +38,12 @@
                               t))
                    :boolean (fn [] (> (math.random) 0.5))})
 
-(set! generate
-      (fn [table-chance]
-        (set table-chance (or table-chance 0.5))
-        (if (> (math.random) 0.5) (generators.number)
-            (> (math.random) 0.5) (generators.string)
-            (> (math.random) table-chance) (generators.table table-chance)
-            :else (generators.boolean))))
+(set generate
+     (fn [table-chance]
+       (local table-chance (or table-chance 0.5))
+       (if (> (math.random) 0.5) (generators.number)
+           (> (math.random) 0.5) (generators.string)
+           (> (math.random) table-chance) (generators.table table-chance)
+           :else (generators.boolean))))
 
 generate

--- a/generate.fnl
+++ b/generate.fnl
@@ -37,12 +37,12 @@
                               t))
                    :boolean (fn [] (> (math.random) 0.5))})
 
-(set generate
-     (fn [table-chance]
-       (set table-chance (or table-chance 0.5))
-       (if (> (math.random) 0.5) (generators.number)
-           (> (math.random) 0.5) (generators.string)
-           (> (math.random) table-chance) (generators.table table-chance)
-           :else (generators.boolean))))
+(set! generate
+      (fn [table-chance]
+        (set table-chance (or table-chance 0.5))
+        (if (> (math.random) 0.5) (generators.number)
+            (> (math.random) 0.5) (generators.string)
+            (> (math.random) table-chance) (generators.table table-chance)
+            :else (generators.boolean))))
 
 generate

--- a/test-macros.fnl
+++ b/test-macros.fnl
@@ -7,5 +7,5 @@
           (set val elt))
         val)
  :defn (fn [name args ...]
-         (list (sym "set") name
+         (list (sym "set!") name
                (list (sym "fn") args ...)))}

--- a/test-macros.fnl
+++ b/test-macros.fnl
@@ -1,11 +1,12 @@
 ;; this module is loaded by the test suite, but these are handy macros to
 ;; have around so feel free to steal them for your own projects.
 {"->" (fn [val ...]
+        (var x val)
         (each [_ elt (pairs [...])]
-          (table.insert elt 2 val)
+          (table.insert elt 2 x)
           (set elt.n (+ 1 elt.n))
-          (set val elt))
-        val)
+          (set x elt))
+        x)
  :defn (fn [name args ...]
-         (list (sym "set!") name
+         (list (sym "global") name
                (list (sym "fn") args ...)))}

--- a/test.lua
+++ b/test.lua
@@ -109,6 +109,8 @@ local cases = {
         ["(let [t []] (table.insert t \"lo\") (. t 1))"]="lo",
         -- set works with multisyms
         ["(let [t {}] (set t.a :multi) (. t :a))"]="multi",
+        -- set works on parent scopes
+        ["(local n 0 )(let [f (fn [] (set n 96))] (f) n)"]=96,
         -- local names with dashes in them
         ["(let [my-tbl {} k :key] (tset my-tbl k :val) my-tbl.key)"]="val",
         -- functions inside each
@@ -291,7 +293,7 @@ local compile_failures = {
     ["(let [false 1] 9)"]="unable to destructure false",
     ["(let [nil 1] 9)"]="unable to destructure nil",
     ["(let [[a & c d] [1 2]] c)"]="rest argument in final position",
-    ["(set a 19)"]="tried to set local",
+    ["(set a 19)"]="isn't in scope",
     -- line numbers
     ["(set)"]="Compile error in `set' unknown:1: expected name and value",
     ["(let [b 9\nq (. tbl)] q)"]="2: expected table and key argument",

--- a/test.lua
+++ b/test.lua
@@ -57,8 +57,8 @@ local cases = {
                   f2 (fn [x y] (* x (+ 2 y)))\
                   f3 (fn [f] (fn [x] (f 5 x)))]\
                   (f 9 5 (f3 f2)))"]=44,
-        -- closures can set variables they close over
-        ["(let [a 11 f (fn [] (set a (+ a 2)))] (f) (f) a)"]=15,
+        -- closures can set vars they close over
+        ["(var a 11) (let [f (fn [] (set a (+ a 2)))] (f) (f) a)"]=15,
         -- partial application
         ["(let [add (fn [x y] (+ x y)) inc (partial add 1)] (inc 99))"]=100,
         ["(let [add (fn [x y z] (+ x y z)) f2 (partial add 1 2)] (f2 6))"]=9,
@@ -77,23 +77,22 @@ local cases = {
         -- method calls work
         ["(: :hello :find :e)"]=2,
         -- method calls don't double side effects
-        ["(do (local a 0) (let [f (fn [] (set a (+ a 1)) :hello)]\
-            (: (f) :find :e)) a)"]=1,
+        ["(var a 0) (let [f (fn [] (set a (+ a 1)) :hi)] (: (f) :find :h)) a"]=1,
     },
 
     conditionals = {
         -- basic if
         ["(let [x 1 y 2] (if (= (* 2 x) y) \"yep\"))"]="yep",
         -- if can contain side-effects
-        ["(let [x 12] (if true (set x 22) 0) x)"]=22,
+        ["(var x 12) (if true (set x 22) 0) x"]=22,
         -- else branch works
         ["(if false \"yep\" \"nope\")"]="nope",
         -- else branch runs on nil
         ["(if non-existent 1 (* 3 9))"]=27,
         -- when is for side-effects
-        ["(when true (set! a 192) (set! z 12)) (+ z a)"]=204,
+        ["(var [a z] [0 0]) (when true (set a 192) (set z 12)) (+ z a)"]=204,
         -- when treats nil as falsey
-        ["(set! a 884) (when nil (set! a 192)) a"]=884,
+        ["(var a 884) (when nil (set a 192)) a"]=884,
         -- when body does not run on false
         ["(when (= 12 88) (os.exit 1)) false"]=false,
     },
@@ -102,7 +101,7 @@ local cases = {
         -- comments
         ["74 ; (require \"hey.dude\")"]=74,
         -- comments go to the end of the line
-        ["(set! x 12) ;; (set! x 99)\n x"]=12,
+        ["(var x 12) ;; (set x 99)\n x"]=12,
         -- calling built-in lua functions
         ["(table.concat [\"ab\" \"cde\"] \",\")"]="ab,cde",
         -- table lookup
@@ -110,15 +109,15 @@ local cases = {
         -- set works with multisyms
         ["(let [t {}] (set t.a :multi) (. t :a))"]="multi",
         -- set works on parent scopes
-        ["(local n 0 )(let [f (fn [] (set n 96))] (f) n)"]=96,
+        ["(var n 0) (let [f (fn [] (set n 96))] (f) n)"]=96,
         -- local names with dashes in them
         ["(let [my-tbl {} k :key] (tset my-tbl k :val) my-tbl.key)"]="val",
         -- functions inside each
-        ["(each [_ ((fn [] (pairs [1])))] (set! i 1)) i"]=1,
+        ["(var i 0) (each [_ ((fn [] (pairs [1])))] (set i 1)) i"]=1,
         -- let with nil value
         ["(let [x 3 y nil z 293] z)"]=293,
         -- nested let inside loop
-        ["(for [_ 1 3] (let [] (table.concat []) (set! a 33))) a"]=33,
+        ["(var a 0) (for [_ 1 3] (let [] (table.concat []) (set a 33))) a"]=33,
     },
 
     destructuring = {
@@ -135,23 +134,25 @@ local cases = {
         ["(let [(a [b [c] d]) ((fn [] (values 4 [2 [1] 9])))] (+ a b c d))"]=16,
         -- multiple values without function wrapper
         ["(let [(a [b [c] d]) (values 4 [2 [1] 9])] (+ a b c d))"]=16,
-        -- set! destructures tables
-        ["(set! [a b c d] [4 2 43 7]) (+ (* a b) (- c d))"]=44,
-        -- set! multiple values
-        ["(set! (a b) ((fn [] (values 4 29)))) (+ a b)"]=33,
+        -- global destructures tables
+        ["(global [a b c d] [4 2 43 7]) (+ (* a b) (- c d))"]=44,
+        -- global works with multiple values
+        ["(global (a b) ((fn [] (values 4 29)))) (+ a b)"]=33,
         -- local keyword
         ["(local (-a -b) ((fn [] (values 4 29)))) (+ -a -b)"]=33,
         -- rest args
         ["(let [[a b & c] [1 2 3 4 5]] (+ a (. c 2) (. c 3)))"]=10,
+        -- all vars get flagged as var
+        ["(var [a [b c]] [1 [2 3]]) (set a 2) (set c 8) (+ a b c)"]=12,
     },
 
     loops = {
         -- numeric loop
-        ["(let [x 0] (for [y 1 5] (set x (+ x 1))) x)"]=5,
+        ["(var x 0) (for [y 1 5] (set x (+ x 1))) x"]=5,
         -- numeric loop with step
-        ["(let [x 0] (for [y 1 20 2] (set x (+ x 1))) x)"]=10,
+        ["(var x 0) (for [y 1 20 2] (set x (+ x 1))) x"]=10,
         -- while loop
-        ["(let [x 0] (*while (< x 7) (set x (+ x 1))) x)"]=7,
+        ["(var x 0) (*while (< x 7) (set x (+ x 1))) x"]=7,
         -- each loop iterates over tables
         ["(let [t {:a 1 :b 2} t2 {}]\
                (each [k v (pairs t)]\
@@ -246,15 +247,15 @@ fennel.eval([[(eval-compiler
 local macro_cases = {
     -- just a boring old set+fn combo
     ["(require-macros \"test-macros\")\
-      (defn hui [x y] (set! z (+ x y))) (hui 8 4) z"]=12,
+      (defn hui [x y] (global z (+ x y))) (hui 8 4) z"]=12,
     -- macros with mangled names
     ["(require-macros \"test-macros\")\
       (-> 9 (+ 2) (* 11))"]=121,
     -- require-macros doesn't leak into new evaluation contexts
     ["(let [(_ e) (pcall (fn [] (-> 8 (+ 2))))] (: e :match :global))"]="global",
     -- macros loaded in function scope shouldn't leak to other functions
-    ["((fn [] (require-macros \"test-macros\") (set! x1 (-> 99 (+ 31)))))\
-      (pcall (fn [] (set! x1 (-> 23 (+ 1)))))\
+    ["((fn [] (require-macros \"test-macros\") (global x1 (-> 99 (+ 31)))))\
+      (pcall (fn [] (global x1 (-> 23 (+ 1)))))\
       x1"]=130,
     -- special form
     ["(reverse-it 1 2 3 4 5 6)"]=1,
@@ -293,7 +294,8 @@ local compile_failures = {
     ["(let [false 1] 9)"]="unable to destructure false",
     ["(let [nil 1] 9)"]="unable to destructure nil",
     ["(let [[a & c d] [1 2]] c)"]="rest argument in final position",
-    ["(set a 19)"]="isn't in scope",
+    ["(set a 19)"]="expected local var a",
+    ["(set [a b c] [1 2 3]) (+ a b c)"]="expected local var",
     -- line numbers
     ["(set)"]="Compile error in `set' unknown:1: expected name and value",
     ["(let [b 9\nq (. tbl)] q)"]="2: expected table and key argument",


### PR DESCRIPTION
I'm a little hesitant about this change because it's not backwards-compatible, but one of the most common mistakes with Lua is accidentally making a typo in an assignment and creating a global when you meant to just give a new value to a local. That's a big part of why `luacheck` is such an important tool.

But this is only a problem because Lua uses the same syntax for setting globals as for setting locals. What if we limited `set` so that it could only give a new value to a local that had already been introduced and used `set!` to change the value of globals?

I've implemented that behavior in this pull request. It's a big change, so it's worth thinking thru. For folks who have existing code, it should be pretty easy to update as the error message is pretty descriptive: `Compile error in `set' in.fnl:3: tried to set local row_str that wasn't in scope; use set! for globals`

But maybe it would be better to leave `set` alone and introduce a new form which only works on locals, and encourage using that where possible? I can't think of a better name though.