### PR TITLE
Add a whole bunch of documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ Fennel (formerly fnl) is a lisp that compiles to Lua. It aims to be easy to use,
 zero overhead compared to handwritten Lua. It's currently a single file Lua library that can
 be dragged into any Lua project.
 
-See [the tutorial](https://github.com/bakpakin/Fennel/tree/master/tutorial.md)
-for an overview of the language features. The `test.lua` suite has usage
-examples for most features. For a small complete example that uses the LÖVE
-game engine, see [pong.fnl](https://p.hagelb.org/pong.fnl.html).
-
 Current features include:
 
 * Full Lua compatibility - You can use any function from Lua.
@@ -18,133 +13,17 @@ Current features include:
 * Ability to write custom special forms - Special forms are s-expressions that, when evaulated, directly output Lua code.
 * Fennel is a library as well as a compiler. Embed it in other projects.
 
-Eventually, I also hope to add optional source maps, either embedded in the comments of the generated code, or in separate files. An optional standard library also needs to be made.
+## Documentation
 
-There is a `#fennel` IRC channel on Freenode where some Fennel users
-and contributors discuss.
+* The [tutorial](tutorial.md) is a great place to start
+* The [reference](reference.md) describes all Fennel special forms
+* The [API listing](api.md) shows how to integrate Fennel into your codebaes
+* The [Lua primer](lua-primer.md) gives a very brief intro to Lua with
+  pointers to further details
+* The [test suite](test.lua) has basic usage examples for most features.
 
-## Lua API
-
-The fennel module exports the following functions. Most functions take
-an `indent` function to override how to indent the compiled Lua output
-or an `accurate` function to ignore indentation and attempt to make
-the lines in the output code match up with the lines in the input code.
-
-### Start a configurable repl
-
-```lua
-fennel.repl([options])
-```
-Takes these additional options:
-
-* `read`, `write`, and `flush`: replacements for equivalents from `io` table.
-* `pp`: a pretty-printer function to apply on values.
-* `env`: an environment table in which to run the code; see the Lua manual.
-
-The pretty-printer defaults to loading `fennelview.fnl` if present and
-falls back to `tostring` otherwise. `fennelview.fnl` will produce
-output that can be fed back into Fennel (other than functions,
-coroutines, etc) but you can use a 3rd-party pretty-printer that
-produces output in Lua format if you prefer.
-
-### Evaulate a string of Fennel
-
-```lua
-local result = fennel.eval(str[, options[, ...]])
-```
-
-The `options` table may contain:
-
-* `env`: same as above.
-* `filename`: override the filename that Lua thinks the code came from.
-
-Additional arguments beyond `options` are passed to the code and
-available as `...`.
-
-### Evaluate a file of Fennel
-
-```lua
-local result = fennel.dofile(filename[, options[, ...]])
-```
-
-The `env` key in `options` and the additional arguments after it work
-the same as with `eval` above.
-
-### Use Lua's built-in require function
-
-```lua
-table.insert(package.loaders or package.searchers, fennel.searcher)
-local mylib = require("mylib") -- will compile and load code in mylib.fnl
-```
-
-Normally Lua's `require` function only loads modules written in Lua,
-but you can install `fennel.searcher` into `package.loaders` (or in
-Lua 5.3+ `package.searchers`) to teach it how to load Fennel code.
-
-The `require` function is different from `fennel.dofile` in that it
-searches the directories in `fennel.path` for `.fnl` files matching
-the module name, and also in that it caches the loaded value to return
-on subsequent calls, while `fennel.dofile` will reload each time. The
-behavior of `fennel.path` mirrors that of Lua's `package.path`.
-
-If you install Fennel into `package.loaders` then you can use the
-3rd-party [lume.hotswap](https://github.com/rxi/lume#lumehotswapmodname) 
-function to reload modules that have been loaded with `require`.
-
-### Compile a string into Lua (can throw errors)
-
-```lua
-local lua = fennel.compileString(str[, options])
-```
-
-### Compile an iterator of bytes into a string of Lua (can throw errors)
-
-```lua
-local lua = fennel.compileStream(strm, options)
-```
-
-### Get an iterator over the bytes in a string
-
-```lua
-local stream = fennel.stringStream(str)
-```
-    
-### Converts an iterator for strings into an iterator over their bytes
-
-Useful for the REPL or reading files in chunks. This will NOT insert
-newlines or other whitespace between chunks, so be careful when using
-with io.read().  Returns a second function, clearstream, which will
-clear the current buffered chunk when called. Useful for implementing
-a repl.
-
-```lua
-local bytestream, clearstream = fennel.granulate(chunks)
-```
-    
-### Converts a stream of bytes to a stream of values
-
-Valuestream gets the next top level value parsed.
-Returns true in the first return value if a value was read, and
-returns nil if and end of file was reached without error. Will error
-on bad input or unexpected end of source.
-
-```lua
-local valuestream = fennel.parser(strm)
-local ok, value = valuestream()
-
--- Or use in a for loop
-for ok, value in valuestream do
-    print(ok, value)
-end
-```
-
-### Compile a data structure (AST) into Lua source code
-
-The code can be loaded via dostring or other methods. Will error on bad input.
-
-```lua
-local lua = fennel.compile(ast)
-```
+For a small complete example that uses the LÖVE game engine, see
+[pong.fnl](https://p.hagelb.org/pong.fnl.html).
 
 ## Example
 
@@ -196,6 +75,7 @@ When given a file without a flag, it will simply load and run the file.
 * [Emacs support](https://gitlab.com/technomancy/fennel-mode)
 * [Wiki](https://github.com/bakpakin/Fennel/wiki)
 * Build: [![CircleCI](https://circleci.com/gh/bakpakin/Fennel.svg?style=svg)](https://circleci.com/gh/bakpakin/Fennel)
+* The `#fennel` IRC channel is [on Freenode](https://webchat.freenode.net/)
 
 ## License
 

--- a/api.md
+++ b/api.md
@@ -1,0 +1,122 @@
+## Fennel's Lua API
+
+The fennel module provides the following functions. Most functions take
+an `indent` function to override how to indent the compiled Lua output
+or an `accurate` function to ignore indentation and attempt to make
+the lines in the output code match up with the lines in the input code.
+
+### Start a configurable repl
+
+```lua
+fennel.repl([options])
+```
+Takes these additional options:
+
+* `read`, `write`, and `flush`: replacements for equivalents from `io` table.
+* `pp`: a pretty-printer function to apply on values.
+* `env`: an environment table in which to run the code; see the Lua manual.
+
+The pretty-printer defaults to loading `fennelview.fnl` if present and
+falls back to `tostring` otherwise. `fennelview.fnl` will produce
+output that can be fed back into Fennel (other than functions,
+coroutines, etc) but you can use a 3rd-party pretty-printer that
+produces output in Lua format if you prefer.
+
+### Evaulate a string of Fennel
+
+```lua
+local result = fennel.eval(str[, options[, ...]])
+```
+
+The `options` table may contain:
+
+* `env`: same as above.
+* `filename`: override the filename that Lua thinks the code came from.
+
+Additional arguments beyond `options` are passed to the code and
+available as `...`.
+
+### Evaluate a file of Fennel
+
+```lua
+local result = fennel.dofile(filename[, options[, ...]])
+```
+
+The `env` key in `options` and the additional arguments after it work
+the same as with `eval` above.
+
+### Use Lua's built-in require function
+
+```lua
+table.insert(package.loaders or package.searchers, fennel.searcher)
+local mylib = require("mylib") -- will compile and load code in mylib.fnl
+```
+
+Normally Lua's `require` function only loads modules written in Lua,
+but you can install `fennel.searcher` into `package.loaders` (or in
+Lua 5.3+ `package.searchers`) to teach it how to load Fennel code.
+
+The `require` function is different from `fennel.dofile` in that it
+searches the directories in `fennel.path` for `.fnl` files matching
+the module name, and also in that it caches the loaded value to return
+on subsequent calls, while `fennel.dofile` will reload each time. The
+behavior of `fennel.path` mirrors that of Lua's `package.path`.
+
+If you install Fennel into `package.loaders` then you can use the
+3rd-party [lume.hotswap](https://github.com/rxi/lume#lumehotswapmodname) 
+function to reload modules that have been loaded with `require`.
+
+### Compile a string into Lua (can throw errors)
+
+```lua
+local lua = fennel.compileString(str[, options])
+```
+
+### Compile an iterator of bytes into a string of Lua (can throw errors)
+
+```lua
+local lua = fennel.compileStream(strm, options)
+```
+
+### Get an iterator over the bytes in a string
+
+```lua
+local stream = fennel.stringStream(str)
+```
+    
+### Converts an iterator for strings into an iterator over their bytes
+
+Useful for the REPL or reading files in chunks. This will NOT insert
+newlines or other whitespace between chunks, so be careful when using
+with io.read().  Returns a second function, clearstream, which will
+clear the current buffered chunk when called. Useful for implementing
+a repl.
+
+```lua
+local bytestream, clearstream = fennel.granulate(chunks)
+```
+    
+### Converts a stream of bytes to a stream of values
+
+Valuestream gets the next top level value parsed.
+Returns true in the first return value if a value was read, and
+returns nil if and end of file was reached without error. Will error
+on bad input or unexpected end of source.
+
+```lua
+local valuestream = fennel.parser(strm)
+local ok, value = valuestream()
+
+-- Or use in a for loop
+for ok, value in valuestream do
+    print(ok, value)
+end
+```
+
+### Compile a data structure (AST) into Lua source code
+
+The code can be loaded via dostring or other methods. Will error on bad input.
+
+```lua
+local lua = fennel.compile(ast)
+```

--- a/lua-primer.md
+++ b/lua-primer.md
@@ -1,0 +1,84 @@
+# Lua Primer
+
+While the [Lua reference manual](https://www.lua.org/manual/5.1/) is
+indispensable, here are the most important parts of Lua you'll need to
+get started. This is meant to give a very brief overview and let you
+know where in the manual to look for further details, not to teach Lua.
+
+## Important functions
+
+* `tonumber`: converts its string argument to a number; takes optional base
+* `tostring`: converts its argument to a string
+* `print`: prints `tostring` of all its arguments separated by tab characters
+* `type`: returns a string describing the type of its argument
+* `pcall`: calls a function in protected mode so errors are not fatal
+* `error`: halts execution and break to the nearest `pcall`
+* `assert`: raises an error if a condition is nil or false
+* `ipairs`: iterates over sequential tables
+* `pairs`: iterates over any table, sequential or not, in undefined order
+* `unpack`: turns a sequential table into multiple values
+* `require`: loads and returns a given module
+
+Note that `tostring` on tables will give unsatisfactory results; you
+will want to use `fennelview` or another pretty-printer for debugging
+and development.
+
+## Important modules
+
+You can explore a module with `(each [k v (pairs math)] (print k v))`
+in the repl to see all the functions and values it contains.
+
+* `math`: all your standard math things including trig and `random`
+* `table`: `concat`, `insert`, `remove`, and `sort` are the main things
+* `string`: all common string operations (except `split` which is absent)
+* `io`: mostly filesystem functions (directory listing is notably absent)
+* `os`: operating system functions like `exit`, `time`, `getenv`, etc
+
+In particular `table.insert` and `table.remove` are intended for
+sequential tables; they will shift over the indices of every element
+after the specified index. To remove something from a non-sequential
+table simply set the field to `nil`.
+
+Note that Lua does not implement regular expressions but its own more
+limited [pattern](https://www.lua.org/pil/20.2.html) language for
+`string.find`, `string.match`, etc.
+
+## Advanced
+
+* `getfenv`/`setfenv`: access to first-class function environments in
+  Lua 5.1; in 5.2 onward use
+  [the _ENV table](http://leafo.net/guides/setfenv-in-lua52-and-above.html)
+  instead
+* `getmetatable`/`setmetatable`: metatables allow you to
+  [override the behavior of tables](https://www.lua.org/pil/13.html)
+  in flexible ways with functions of your choice
+* `coroutine`: the coroutine module allows you to do
+  [flexible control transfer](http://leafo.net/posts/itchio-and-coroutines.html)
+  in a first-class way
+* `package`: this module tracks and controls the loading of modules
+* `arg`: table of command-line arguments passed to the process
+* `...`: arguments passed to the current function; acts as multiple values
+* `select`: most commonly used with `...` to find the number of arguments
+* `xpcall`: acts like `pcall` but accepts a handler; used to get a
+  full stack trace rather than a single line number for errors
+
+## Lua loading
+
+These are used for loading Lua code. The `load*` functions return a
+"chunk" function which must be called before the code gets run, but
+`dofile` executes immediately.
+
+
+* `dofile`
+* `load`
+* `loadfile`
+* `loadstring`
+
+## Obscure
+
+* `_G`: a table of all globals
+* `_VERSION`: the current version of Lua being used as a string
+* `collectgarbage`: you hopefully will never need this
+* `debug`: see the Lua manual for this module
+* `next`: needed for implementing your own iterators
+* `rawequal`/`rawget`/`rawlen`/`rawset`: operations which bypass metatables

--- a/tutorial.md
+++ b/tutorial.md
@@ -287,7 +287,7 @@ You can write your own function which returns multiple values with `values`:
         (fn [filename]
           (if (valid-file-name? filename)
               (open-file filename)
-              (values nil (.. "Invalid filename: " filename))))
+              (values nil (.. "Invalid filename: " filename)))))
 ```
 
 If you detect a serious error that needs to be signaled beyond just


### PR DESCRIPTION
* Move API docs to a separate file
* Add reference listing out all special forms
* Add Lua primer with an overview of Lua concepts and pointers to the manual

I still want to improve the examples in the readme.

Do you think it's worth keeping the Luarocks section around? I suspect most people would be better off using git instead since there are no dependencies.