### PR TITLE
Teach the `.` form nested indexing

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1007,10 +1007,18 @@ end
 
 -- Wrapper for table access
 SPECIALS['.'] = function(ast, scope, parent)
-    assertCompile(#ast == 3, "expected table and key argument", ast)
+    local len = #ast
+    assertCompile(len > 1, "expected table argument", ast)
     local lhs = compile1(ast[2], scope, parent, {nval = 1})
-    local rhs = compile1(ast[3], scope, parent, {nval = 1})
-    return ('%s[%s]'):format(tostring(lhs[1]), tostring(rhs[1]))
+    if len == 2 then
+        return tostring(lhs[1])
+    else
+        local indices = {}
+        for i = 3, len do
+            table.insert(indices, tostring(compile1(ast[i], scope, parent, {nval = 1})[1]))
+        end
+        return tostring(lhs[1]) .. '[' .. table.concat(indices, '][') .. ']'
+    end
 end
 
 local function inScope(name, scope)

--- a/reference.md
+++ b/reference.md
@@ -228,9 +228,11 @@ Example: `(+ (# [1 2 3 nil 8]) (# "abc"))` -> `6` or `8`
 
 ### `.` table lookup
 
-Looks up a given key in a table.
+Looks up a given key in a table. Multiple arguments will index repeatedly.
 
 Example: `(. mytbl myfield)`
+
+Example: `(let [t {:a [2 3 4]}] (. t :a 2))` -> `3`
 
 Note that if the field name is known at compile time, you don't need
 this and can just use `mytbl.field`.

--- a/test.lua
+++ b/test.lua
@@ -107,6 +107,10 @@ local cases = {
         ["(table.concat [\"ab\" \"cde\"] \",\")"]="ab,cde",
         -- table lookup
         ["(let [t []] (table.insert t \"lo\") (. t 1))"]="lo",
+        -- nested table lookup
+        ["(let [t [[21]]] (+ (. (. t 1) 1) (. t 1 1)))"]=42,
+        -- table lookup base case
+        ["(let [x 17] (. 17))"]=17,
         -- set works with multisyms
         ["(let [t {}] (set t.a :multi) (. t :a))"]="multi",
         -- set works on parent scopes
@@ -304,7 +308,7 @@ local compile_failures = {
     ["(not true false)"]="expected one argument",
     -- line numbers
     ["(set)"]="Compile error in `set' unknown:1: expected name and value",
-    ["(let [b 9\nq (. tbl)] q)"]="2: expected table and key argument",
+    ["(let [b 9\nq (.)] q)"]="2: expected table argument",
     ["(do\n\n\n(each \n[x 34 (pairs {})] 21))"]="4: expected iterator symbol",
     ["(fn []\n(for [32 34 32] 21))"]="2: expected iterator symbol",
     ["\n\n(let [f (lambda []\n(local))] (f))"]="4: expected name and value",


### PR DESCRIPTION
The only thing I'm not sure about here is whether you'd want `(. x)` to evaluate to `x` or not. It seems useful as a base case of indexing that would make macros easier to write (in the same way `(+)` evaluates to `0` and `(+ x)` to `x`).

Closes #45.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bakpakin/fennel/48)
<!-- Reviewable:end -->
