### PR TITLE
 Expose type checks to compiler environment

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1449,7 +1449,7 @@ local function repl(options)
     end
 
     local function defaultOnValues(xs)
-        io.write(unpack(xs, 1, #xs))
+        io.write(table.concat(xs, '\t'))
         io.write('\n')
         env._ = xs[1]
         env.__ = xs

--- a/test-macros.fnl
+++ b/test-macros.fnl
@@ -8,5 +8,6 @@
           (set x elt))
         x)
  :defn (fn [name args ...]
+         (assert (sym? name) "defn: function names must be symbols")
          (list (sym "global") name
                (list (sym "fn") args ...)))}

--- a/test.lua
+++ b/test.lua
@@ -306,6 +306,9 @@ local compile_failures = {
     ["(set a 19)"]="expected local var a",
     ["(set [a b c] [1 2 3]) (+ a b c)"]="expected local var",
     ["(not true false)"]="expected one argument",
+    -- compiler environment
+    ["(require-macros \"test-macros\")\n(defn [:foo] [] nil)"]=
+        "defn: function names must be symbols",
     -- line numbers
     ["(set)"]="Compile error in `set' unknown:1: expected name and value",
     ["(let [b 9\nq (.)] q)"]="2: expected table argument",


### PR DESCRIPTION
Macro writers can't currently tell if a one-item table with a string is a normal array-style table (`["foo"]`), a list (`("foo")`), or a symbol (`foo`). This PR exposes the compiler's checks to that macro writers can have more control over syntax and provide better errors. (Also included is a fix for the REPL so that it matches Lua's behavior and actually visually splits up multiple return values.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bakpakin/fennel/49)
<!-- Reviewable:end -->
