### PR TITLE
Make --accurate the default option

### DIFF
--- a/api.md
+++ b/api.md
@@ -1,9 +1,6 @@
 ## Fennel's Lua API
 
-The fennel module provides the following functions. Most functions take
-an `indent` function to override how to indent the compiled Lua output
-or an `accurate` function to ignore indentation and attempt to make
-the lines in the output code match up with the lines in the input code.
+The fennel module provides the following functions.
 
 ### Start a configurable repl
 
@@ -78,11 +75,28 @@ function to reload modules that have been loaded with `require`.
 local lua = fennel.compileString(str[, options])
 ```
 
+Accepts `indent` as a string in `options` causing output to be
+indented using that string instead of attempting to correlate output
+line numbers with source; results in output that is more readable but
+will not give helpful stack traces.
+
 ### Compile an iterator of bytes into a string of Lua (can throw errors)
 
 ```lua
-local lua = fennel.compileStream(strm, options)
+local lua = fennel.compileStream(strm[, options])
 ```
+
+Accepts `indent` in `options` as per above.
+
+### Compile a data structure (AST) into Lua source code (can throw errors)
+
+The code can be loaded via dostring or other methods. Will error on bad input.
+
+```lua
+local lua = fennel.compile(ast[, options])
+```
+
+Accepts `indent` in `options` as per above.
 
 ### Get an iterator over the bytes in a string
 
@@ -117,12 +131,4 @@ local ok, value = valuestream()
 for ok, value in valuestream do
     print(ok, value)
 end
-```
-
-### Compile a data structure (AST) into Lua source code
-
-The code can be loaded via dostring or other methods. Will error on bad input.
-
-```lua
-local lua = fennel.compile(ast)
 ```

--- a/fennel
+++ b/fennel
@@ -12,16 +12,7 @@ Usage: fennel [FLAG] [FILE]
 
   When not given a flag, runs the file given as the first argument.]]
 
-local flags = {"--accurate", "--debug"}
 local options = {}
-for _, flag in pairs(flags) do
-    for i = #arg, 1, -1 do
-        if arg[i] == flag then
-            table.remove(arg, i)
-            options[flag:gsub("[-][-]", "")] = true
-        end
-    end
-end
 
 if arg[1] == "--repl" or #arg == 0 then
     local initFilename = (os.getenv("HOME") or "") .. "/.fennelrc"
@@ -34,10 +25,14 @@ if arg[1] == "--repl" or #arg == 0 then
     print("Welcome to fennel!")
     fennel.repl(options)
 elseif arg[1] == "--compile" then
+    if arg[2] == "--indent" then
+        options.indent = table.remove(arg, 3)
+        table.remove(arg, 2)
+    end
     for i = 2, #arg do
         local f = assert(io.open(arg[i], "rb"))
         options.filename=arg[i]
-        if options.debug then
+        if os.getenv("DEBUG") then
             fennel.compileString(f:read("*all"), options)
         else
             local ok, val = pcall(fennel.compileString, f:read("*all"), options)
@@ -48,7 +43,7 @@ elseif arg[1] == "--compile" then
     end
 elseif #arg >= 1 and arg[1] ~= "--help" then
     local filename = table.remove(arg, 1) -- let the script have remaining args
-    if options.debug then
+    if os.getenv("DEBUG") then
         fennel.dofile(filename, { accurate=true })
     else
         local ok, val = pcall(fennel.dofile, filename, { accurate=true })

--- a/fennel.lua
+++ b/fennel.lua
@@ -463,12 +463,9 @@ local function gensym(...)
 end
 
 -- Flatten a tree of indented Lua source code lines.
--- Tab is what is used to indent a block. By default it is two spaces.
+-- Tab is what is used to indent a block.
 local function flattenChunkPretty(chunk, tab, depth)
-    if type(chunk) == 'string' then
-        return chunk
-    end
-    tab = tab or '  ' -- 2 spaces
+    if type(chunk) == 'string' then return chunk end
     for i = 1, #chunk do
         local sub = flattenChunkPretty(chunk[i], tab, depth + 1)
         if depth > 2 then sub = tab .. sub:gsub('\n', '\n' .. tab) end
@@ -497,10 +494,12 @@ local function flattenChunkTables(chunk, out, lastLine, file)
     return lastLine
 end
 
--- Turn a chunk into a single code string, either with indentation (default)
--- or by attempting to preserve line numbering if accurate is true.
-local function flattenChunk(chunk, tab, accurate)
-    if accurate then
+-- Turn a chunk into a single code string, either with indentation if given
+-- or by attempting to preserve line numbering.
+local function flattenChunk(chunk, tab)
+    if tab then
+        return flattenChunkPretty(chunk, tab, 0)
+    else
         local out = {}
         local lineCount = flattenChunkTables(chunk, out, 1, chunk.file)
         -- fill in the gaps
@@ -508,8 +507,6 @@ local function flattenChunk(chunk, tab, accurate)
             if not out[i] then out[i] = "" end
         end
         return table.concat(out, "\n")
-    else
-        return flattenChunkPretty(chunk, tab, 0)
     end
 end
 
@@ -1013,6 +1010,7 @@ SPECIALS['.'] = function(ast, scope, parent)
     return ('%s[%s]'):format(tostring(lhs[1]), tostring(rhs[1]))
 end
 
+-- TODO: referring to a global can put an entry in the manglings table
 local function inScope(name, scope)
     return scope.manglings[name] or scope.parent and inScope(name, scope.parent)
 end
@@ -1374,7 +1372,7 @@ local function compile(ast, options)
     local scope = options.scope or makeScope(GLOBAL_SCOPE)
     local exprs = compile1(ast, scope, chunk, {tail = true})
     keepSideEffects(exprs, chunk, nil, ast)
-    return flattenChunk(chunk, options.indent, options.accurate)
+    return flattenChunk(chunk, options.indent)
 end
 
 local function compileStream(strm, options)
@@ -1392,7 +1390,7 @@ local function compileStream(strm, options)
         })
         keepSideEffects(exprs, chunk, nil, vals[i])
     end
-    return flattenChunk(chunk, options.indent, options.accurate)
+    return flattenChunk(chunk, options.indent)
 end
 
 local function compileString(str, options)
@@ -1408,7 +1406,7 @@ local function eval(str, options, ...)
 end
 
 local function dofile_fennel(filename, options, ...)
-    options = options or { accurate = true }
+    options = options or {}
     local f = assert(io.open(filename, "rb"))
     local source = f:read("*all")
     f:close()


### PR DESCRIPTION
I think it makes sense to turn this on by default for all entry points that actually run code.

Here I have it so you can pass `--indent "  "` to the `--compile` command... It might make more sense to make the nicely-indented output the default for `--compile` and not for the others, but I decided to err on the side of consistency. Hopefully as the compiler matures and the bugs get shaken out, the need for readable Lua output will be reduced.