### PR TITLE
Remove some unused specials and functions.

### DIFF
--- a/generate.fnl
+++ b/generate.fnl
@@ -33,7 +33,7 @@
                               (for [_ 1 (math.random 16)]
                                 ;; no nans plz
                                 (set k (generate 0.9))
-                                (*while (~= k k) (set k (generate 0.9)))
+                                (while (~= k k) (set k (generate 0.9)))
                                 (tset t k (generate (* table-chance 1.5))))
                               t))
                    :boolean (fn [] (> (math.random) 0.5))})

--- a/reference.md
+++ b/reference.md
@@ -273,6 +273,22 @@ Example:
       (values nil (.. "Invalid filename: " filename))))
 ```
 
+### `while` good old while loop
+
+Loops over a body until a condition is met. Uses a native
+Lua while loop, so is preferable to a lambda function and tail recursion.
+
+Example:
+
+```
+(do
+  (var done? false)
+  (while (not done?)
+    (print :not-done)
+    (when (> (math.random) 0.95)
+      (set done? true))))
+```
+
 ## Meta
 
 ### `require-macros`
@@ -288,11 +304,7 @@ they are subject to change or rely on compiler internals that
 shouldn't be relied upon.
 
 * `eval-compiler`
-* `$`
-* `*while`
 * `macro`
 * `special`
 * `luaexpr`
 * `luastatement`
-* `pack`
-* `block`

--- a/test.lua
+++ b/test.lua
@@ -161,7 +161,7 @@ local cases = {
         -- numeric loop with step
         ["(var x 0) (for [y 1 20 2] (set x (+ x 1))) x"]=10,
         -- while loop
-        ["(var x 0) (*while (< x 7) (set x (+ x 1))) x"]=7,
+        ["(var x 0) (while (< x 7) (set x (+ x 1))) x"]=7,
         -- each loop iterates over tables
         ["(let [t {:a 1 :b 2} t2 {}]\
                (each [k v (pairs t)]\


### PR DESCRIPTION
Remove block, $, pack, and rename *while to while.
Expose fennel module at compile time.

I have removed some of the unnecessary special forms and also made it clear that in the eval-compiler
context, the fennel module is exposed. This means that in require-macro, you can do stuff like `(fennel.eval "(print :hi)")` for your extra meta needs.