### PR TITLE
A version of the thread last macro, AKA ->>.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1563,6 +1563,13 @@ local stdmacros = [===[
           (set elt.n (+ 1 elt.n))
           (set x elt))
         x)
+ "->>" (fn [val ...]
+         (var x val)
+         (each [_ elt (pairs [...])]
+           (table.insert elt x)
+           (set elt.n (+ 1 elt.n))
+           (set x elt))
+         x)
  :defn (fn [name args ...]
          (assert (sym? name) "defn: function names must be symbols")
          (list (sym "global") name


### PR DESCRIPTION
This is the version of `->>` that I've been using locally, and it appears to work(!). But as I just copied from the implementation of `->` I'm not sure that it is correct. In particular I wasn't sure about this line:

    (set elt.n (+ 1 elt.n))