### PR TITLE
When macro

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -308,8 +308,7 @@ local compile_failures = {
     ["(set [a b c] [1 2 3]) (+ a b c)"]="expected local var",
     ["(not true false)"]="expected one argument",
     -- compiler environment
-    ["(require-macros \"test-macros\")\n(defn [:foo] [] nil)"]=
-        "defn: function names must be symbols",
+    ["(defn [:foo] [] nil)"]="defn.*function names must be symbols",
     -- line numbers
     ["(set)"]="Compile error in `set' unknown:1: expected name and value",
     ["(let [b 9\nq (.)] q)"]="2: expected table argument",
@@ -317,6 +316,8 @@ local compile_failures = {
     ["(fn []\n(for [32 34 32] 21))"]="2: expected iterator symbol",
     ["\n\n(let [f (lambda []\n(local))] (f))"]="4: expected name and value",
     ["(do\n\n\n(each \n[x (pairs {})] (when)))"]="5: expected body",
+    -- macro errors have macro names in them
+    ["\n(when)"]="Compile error in .when. unknown:2",
 }
 
 print("Running tests for compile errors...")


### PR DESCRIPTION
I started converting `when` over to a macro, and it caused some test failures because the error message didn't have proper line numbering. I think it's necessary to expose `assertCompile` to Fennel code in compiler scope. However, just exposing the function itself isn't enough; the macros also need the ast node, because that's where the actual macro name and line number info is stored.

I started trying to find a way to expose this, but it was getting kind of out of control. The problem is that the ast node can't be exposed in `makeCompilerEnv` because it's not known yet, so you have to find another way to expose it to the macro. My first attempt was to pass it as the first argument to the macro, but that's counter-intuitive; no one expects the macro to get more arguments than it's called with.

What I ended up doing was exposing an `assert-compile` function into the macro's environment table using `getfenv`. But the `assert-compile` I expose is a wrapper around the regular `assertCompile` which automatically passes in the `ast` argument in the right place, so the macro author doesn't have to think about it; `assert-compile` just takes the same args as `assert`. (Maybe it should be renamed to just `assert`?) 

Unfortunately to do this I had to add a port of `getfenv` which works on 5.2+, so I'm not thrilled with this approach. Definitely interested in hearing alternative ideas if you've got any.