### PR TITLE
Fix loading of fennelview from any directory.

### DIFF
--- a/fennel
+++ b/fennel
@@ -1,6 +1,7 @@
 #!/usr/bin/env lua
 
-package.path = arg[0]:match("(.-)[^\\/]+$") .. "?.lua;" .. package.path
+local fennel_dir = arg[0]:match("(.-)[^\\/]+$")
+package.path = fennel_dir .. "?.lua;" .. package.path
 local fennel = require('fennel')
 
 local help = [[
@@ -15,6 +16,10 @@ Usage: fennel [FLAG] [FILE]
 local options = {}
 
 if arg[1] == "--repl" or #arg == 0 then
+    local ppok, pp = pcall(fennel.dofile, fennel_dir .. "fennelview.fnl", options)
+    if ppok then
+       options.pp = pp
+    end
     local initFilename = (os.getenv("HOME") or "") .. "/.fennelrc"
     local init = io.open(initFilename, "rb")
     if init then

--- a/fennel.lua
+++ b/fennel.lua
@@ -1387,9 +1387,6 @@ local function repl(options)
 
     local opts = options or {}
 
-    local ppok, pp = pcall(dofile_fennel, "fennelview.fnl", opts)
-    if not ppok then pp = tostring end
-
     local env = opts.env or setmetatable({}, {
         __index = _ENV or _G
     })
@@ -1420,7 +1417,7 @@ local function repl(options)
     local readChunk = opts.readChunk or defaultReadChunk
     local onValues = opts.onValues or defaultOnValues
     local onError = opts.onError or defaultOnError
-    pp = opts.pp or pp
+    local pp = opts.pp or tostring
 
     -- Make parser
     local bytestream, clearstream = granulate(readChunk)


### PR DESCRIPTION
This change loads `fennelview` inside the wrapper script `fennel` instead of inside `fennel.lua`. This means that the calling code has access to the "install" directory, I've called this fennel_dir in the code, and can therefore call fennel.dofile with the full path to the fennelview file.

Fixes #56.

(sorry about the other PR, I created it with the wrong account!)