### PR TITLE
Teach Fennel to load ./package/init.fnl

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1558,7 +1558,7 @@ local module = {
     eval = eval,
     repl = repl,
     dofile = dofile_fennel,
-    path = "./?.fnl",
+    path = "./?.fnl;./?/init.fnl",
     traceback = traceback
 }
 


### PR DESCRIPTION
When requiring `package`, `./package/init.fnl` is searched for after `./package.fnl`, as Lua does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bakpakin/fennel/64)
<!-- Reviewable:end -->
