### PR TITLE
[fennelview] Be more permissive in the map keys that are printed as keywords.

### DIFF
--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -102,7 +102,8 @@
                               (puts self " ]")))
 
 (local put-key (fn [self k]
-                 (if (and (= (type k) "string") (not (: k :find "%W")))
+                 (if (and (= (type k) "string")
+                          (: k :find "^[%w?\\^_`!#$%&*+-./@~:|<=>]+$"))
                      (puts self ":" k)
                      (put-value self k))))
 


### PR DESCRIPTION
I've only added `- _ > <` which is less permissive than then fennel parser. If people think we should allow more characters here then I'm happy to extend this PR to include more characters.

My reasoning for not extending to the full range of fennel keywords was that I wondered if there was an implicit heuristic going on here, e.g. if a keyword/string includes certain characters then it could've been written as a keyword but it is more idiomatic to write it as a string.