### PR TITLE
Fix if soundness

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1147,19 +1147,25 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
     -- Emit code
     local s = gensym(scope)
     local buffer = {}
+    local lastBuffer = buffer
     for i = 1, #branches do
         local branch = branches[i]
-        local fstr = i == 1 and 'if %s then' or 'elseif %s then'
-        local condLine = fstr:format(tostring(branch.cond[1]))
-        emit(buffer, branch.condchunk, ast)
-        emit(buffer, condLine, ast)
-        emit(buffer, branch.chunk, ast)
+        local condLine = ('if %s then'):format(tostring(branch.cond[1]))
+        emit(lastBuffer, branch.condchunk, ast)
+        emit(lastBuffer, condLine, ast)
+        emit(lastBuffer, branch.chunk, ast)
         if i == #branches then
             if hasElse then
-                emit(buffer, 'else', ast)
-                emit(buffer, elseBranch.chunk, ast)
+                emit(lastBuffer, 'else', ast)
+                emit(lastBuffer, elseBranch.chunk, ast)
             end
-            emit(buffer, 'end', ast)
+            emit(lastBuffer, 'end', ast)
+        else
+            emit(lastBuffer, 'else', ast)
+            local nextBuffer = {}
+            emit(lastBuffer, nextBuffer, ast)
+            emit(lastBuffer, 'end', ast)
+            lastBuffer = nextBuffer
         end
     end
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -1139,6 +1139,7 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
         local branch = compileBody(i + 1)
         branch.cond = cond
         branch.condchunk = condchunk
+        branch.nested = i ~= 2 and next(condchunk, nil) == nil
         table.insert(branches, branch)
     end
     local hasElse = #ast > 3 and #ast % 2 == 0
@@ -1150,7 +1151,8 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
     local lastBuffer = buffer
     for i = 1, #branches do
         local branch = branches[i]
-        local condLine = ('if %s then'):format(tostring(branch.cond[1]))
+        local fstr = not branch.nested and 'if %s then' or 'elseif %s then'
+        local condLine = fstr:format(tostring(branch.cond[1]))
         emit(lastBuffer, branch.condchunk, ast)
         emit(lastBuffer, condLine, ast)
         emit(lastBuffer, branch.chunk, ast)
@@ -1160,7 +1162,7 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
                 emit(lastBuffer, elseBranch.chunk, ast)
             end
             emit(lastBuffer, 'end', ast)
-        else
+        elseif not branches[i + 1].nested then
             emit(lastBuffer, 'else', ast)
             local nextBuffer = {}
             emit(lastBuffer, nextBuffer, ast)

--- a/test.lua
+++ b/test.lua
@@ -90,6 +90,8 @@ local cases = {
         ["(if false \"yep\" \"nope\")"]="nope",
         -- else branch runs on nil
         ["(if non-existent 1 (* 3 9))"]=27,
+        -- else works with temporaries
+        ["(let [a {:b \"foo\"}] (if false \"yep\" (: a.b :len) \"uh-huh\" \"nope\"))"]="uh-huh",
         -- when is for side-effects
         ["(var [a z] [0 0]) (when true (set a 192) (set z 12)) (+ z a)"]=204,
         -- when treats nil as falsey


### PR DESCRIPTION
While updating [otouto](https://github.com/topkecleon/otouto)'s vendored Fennel, I found that this Fennel code
```
(if (: (a) :a)
    1
    (: (b) :b)
    2
    ; else
    3)
```
compiles to this Lua
```
  local _0_ = a()
if _0_[("a")](_0_) then
  return 1
  local _1_ = b()
elseif _1_[("b")](_1_) then
  return 2
else
  return 3
end
```
which is unsound, as the temporary variable `_1_` that holds the result of `(b)` is created under the previous branch as dead code.

This is fixed by keeping track of whether there's a condchunk for a conditional branch. There aren't any tests for this yet, but I wanted to get the PR up quickly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bakpakin/fennel/66)
<!-- Reviewable:end -->
