### PR TITLE
Remove traceback's parsing out of important debug info.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1458,7 +1458,7 @@ local function traceback(msg, start)
     local level = start or 2 -- Can be used to skip some frames
     local lines = {}
     if msg then
-        table.insert(lines, errstr and ('fennel error: ' .. errstr) or msg)
+        table.insert(lines, msg)
     end
     table.insert(lines, 'stack traceback:')
     while true do

--- a/fennel.lua
+++ b/fennel.lua
@@ -1458,7 +1458,6 @@ local function traceback(msg, start)
     local level = start or 2 -- Can be used to skip some frames
     local lines = {}
     if msg then
-        local _, _, errstr = msg:match("^([^:]+):([^:]+): (.*)$")
         table.insert(lines, errstr and ('fennel error: ' .. errstr) or msg)
     end
     table.insert(lines, 'stack traceback:')


### PR DESCRIPTION
This change removes [line 1461 of fennel.lua](https://github.com/bakpakin/Fennel/blob/309778b56dc6e256fe6071e1a5da9600cf8b7f38/fennel.lua#L1461) which strips debugging information from error messages in the traceback function.

In the current version, a compiler error doesn't give useful information like the function name, file name, or line number; only the actual error message. For example:

```
~/doc/lua/Fennel> 'fennel' ../test.fnl 
fennel error: expected name and value
stack traceback:
  [C]: in function 'error'
  /usr/share/lua/5.3/fennel.lua:365: in function 'assertCompile'
  /usr/share/lua/5.3/fennel.lua:1059: in function 'special'
  /usr/share/lua/5.3/fennel.lua:682: in function 'compile1'
  /usr/share/lua/5.3/fennel.lua:1373: in function ?
  /usr/share/lua/5.3/fennel.lua:1438: in function ?
  [C]: in function 'xpcall'
  /usr/lib/luarocks/rocks-5.3/fennel/scm-1/bin/fennel:21: in function 'dosafe'
  /usr/lib/luarocks/rocks-5.3/fennel/scm-1/bin/fennel:75: in main chunk
  [C]: in ?
```

With this change:

```
~/doc/lua/Fennel> ./fennel ../test.fnl 
Compile error in 'local' ../test.fnl:1: expected name and value
stack traceback:
  [C]: in function 'error'
  ./fennel.lua:365: in function 'assertCompile'
  ./fennel.lua:1098: in function 'special'
  ./fennel.lua:709: in function 'compile1'
  ./fennel.lua:1437: in function ?
  ./fennel.lua:1501: in function ?
  [C]: in function 'xpcall'
  ./fennel:21: in function 'dosafe'
  ./fennel:75: in main chunk
  [C]: in ?
```

(The content of `test.fnl` is `(local [a 1])`.)