### PR TITLE
Remove :else

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -205,7 +205,6 @@ for multiple conditions compiling into `elseif` branches:
       "even"
       (= 0 (% x 10))
       "multiple of ten"
-      :else
       "I dunno, something else"))
 ```
 


### PR DESCRIPTION
Remove :else, as the compiler currently doesn't recognize it as any sort of special form, merely emitting "else" if the if-statement check.