### PR TITLE
Better ops

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1396,14 +1396,12 @@ SPECIALS[':'] = function(ast, scope, parent)
         table.concat(args, ', ')), 'statement')
 end
 
-local function defineArithmeticSpecial(name, unaryPrefix, zeroArity)
+local function defineArithmeticSpecial(name, zeroArity, unaryPrefix)
     local paddedOp = ' ' .. name .. ' '
     SPECIALS[name] = function(ast, scope, parent)
         local len = #ast
         if len == 1 then
-            if zeroArity == nil then
-                error 'Expected more than 0 arguments'
-            end
+            assertCompile(zeroArity ~= nil, 'Expected more than 0 arguments', ast)
             return expr(zeroArity, 'literal')
         else
             local operands = {}
@@ -1416,10 +1414,11 @@ local function defineArithmeticSpecial(name, unaryPrefix, zeroArity)
                 end
             end
             if #operands == 1 then
-                if not unaryPrefix then
-                    error "Expected more than 1 argument"
+                if unaryPrefix then
+                    return '(' .. unaryPrefix .. paddedOp .. operands[1] .. ')'
+                else
+                    return operands[1]
                 end
-                return '(' .. unaryPrefix .. paddedOp .. operands[1] .. ')'
             else
                 return '(' .. table.concat(operands, paddedOp) .. ')'
             end
@@ -1427,16 +1426,16 @@ local function defineArithmeticSpecial(name, unaryPrefix, zeroArity)
     end
 end
 
-defineArithmeticSpecial('+', '0', 0)
-defineArithmeticSpecial('..', "''", "''")
+defineArithmeticSpecial('+', '0')
+defineArithmeticSpecial('..', "''")
 defineArithmeticSpecial('^')
-defineArithmeticSpecial('-', '0', 0)
-defineArithmeticSpecial('*', '1', 1)
+defineArithmeticSpecial('-', nil, '')
+defineArithmeticSpecial('*', '1')
 defineArithmeticSpecial('%')
-defineArithmeticSpecial('/', '1', 1)
-defineArithmeticSpecial('//', '1', 1)
-defineArithmeticSpecial('or')
-defineArithmeticSpecial('and')
+defineArithmeticSpecial('/', nil, '1')
+defineArithmeticSpecial('//', nil, '1')
+defineArithmeticSpecial('or', 'false')
+defineArithmeticSpecial('and', 'true')
 
 local function defineComparatorSpecial(name, realop)
     local op = realop or name

--- a/test.lua
+++ b/test.lua
@@ -18,11 +18,13 @@ local cases = {
         ["(+ 1 2 (^ 1 2))"]=4,
         ["(+ 1 2 (- 1 2))"]=2,
         ["(% 1 2 (- 1 2))"]=0,
+        -- 1 arity results
+        ["(- 1)"]=-1,
+        ["(/ 2)"]=1/2,
+        -- ["(// 2)"]=1//2,
         -- 0 arity results
         ["(+)"]=0,
-        ["(-)"]=0,
         ["(*)"]=1,
-        ["(/)"]=1
     },
 
     booleans = {
@@ -33,6 +35,12 @@ local cases = {
         ["(not true)"]=false,
         ["(not 39)"]=false,
         ["(not nil)"]=true,
+        -- 1 arity results
+        ["(or 5)"]=5,
+        ["(and 5)"]=5,
+        -- 0 arity results
+        ["(or)"]=false,
+        ["(and)"]=true,
     },
 
     comparisons = {


### PR DESCRIPTION
Two commits dealing with operators. I'll reproduce the messages here:

# Saner arithmetic op behavior for arities 0 and 1

Arithmetic special forms now don't always have a unary prefix if they have a zero arity identity. Example:

| Fennel    | old output | new output |
|-----------|------------|------------|
| `(+ 1 2)` | `(1 + 2)`  | `(1 + 2)`  |
| `(+ 1)`   | `(0 + 1)`  | `1`        |
| `(+)`     | `0`        | `0`        |

Subtraction and division now don't have an identity, matching both how they don't form semigroups over the reals (as they're not associative) and with Common Lisp's behavior. (/ 5) still compiles to (1 / 5).

The `or` and `and` operators now have identities of `false` and `true`, respectively, matching with their monoidal identities over the booleans and with their Common Lisp counterparts.

`defineArithmeticSpecial` now generates forms that use `assertCompile` to error instead of Lua's `error`, fixing their compile error messages.

The test for the `//` form is commented out due to the operator's introduction in Lua 5.3.

# Prettify table and comparator output

Tables themselves now are not wrapped in parentheses. Everything I've ran passed, but if this does break code, tests should be added for those situations and the parentheses should be able to be added for that situation only, when necessary.

`defineComparatorSpecial` now uses parentheses like `defineArithmeticSpecial` does, wrapping the whole expression in them as opposed to the left and right hand sides. This works because any expression that could cause precedence confusion (arithmetic or comparator operators) will be wrapped in parentheses, and the output looks more like hand-written Lua. Example:

| Fennel                  | old output                  | new output              |
|-------------------------|-----------------------------|-------------------------|
| `(< 1 2)`               | `(1) < (2)`                 | `(1 < 2)`               |
| `(< 1 2 3)`             | `(1) < (2) and ((2) < (3))` | `((1 < 2) and (2 < 3))` |
| `(and (< 1 2) (* 3 5))` | `((1) < (2) and (3 * 5))`   | `((1 < 2) and (3 * 5))` |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bakpakin/fennel/80)
<!-- Reviewable:end -->
