### PR TITLE
Make strict mode default for live compilation functions.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1575,8 +1575,19 @@ local function traceback(msg, start)
     return table.concat(lines, '\n')
 end
 
+local function currentGlobalNames()
+    local names = {}
+    for k in pairs(_G) do table.insert(names, k) end
+    return names
+end
+
 local function eval(str, options, ...)
     options = options or {}
+    -- eval and dofile are considered "live" entry points, so we can assume
+    -- that the globals available at compile time are a reasonable allowed list
+    if options.allowedGlobals == nil then
+        options.allowedGlobals = currentGlobalNames()
+    end
     local luaSource = compileString(str, options)
     local loader = loadCode(luaSource, options.env,
         options.filename and ('@' .. options.filename) or str)
@@ -1585,6 +1596,9 @@ end
 
 local function dofile_fennel(filename, options, ...)
     options = options or {sourcemap = true}
+    if options.allowedGlobals == nil then
+        options.allowedGlobals = currentGlobalNames()
+    end
     local f = assert(io.open(filename, "rb"))
     local source = f:read("*all")
     f:close()
@@ -1596,6 +1610,11 @@ end
 local function repl(options)
 
     local opts = options or {}
+    -- This would get set for us when calling eval, but we want to seed it
+    -- with a value that is persistent so it doesn't get reset on each eval.
+    if opts.allowedGlobals == nil then
+        options.allowedGlobals = currentGlobalNames()
+    end
 
     local env = opts.env or setmetatable({}, {
         __index = _ENV or _G
@@ -1759,20 +1778,37 @@ local function makeCompilerEnv(ast, scope, parent)
     }, { __index = _ENV or _G })
 end
 
+local function macroGlobals(env)
+    if allowedGlobals then
+        local allowed = {}
+        for k in pairs(env) do
+            local g = globalUnmangling(k)
+            table.insert(allowed, g)
+        end
+        for _,k in pairs(allowedGlobals) do
+            table.insert(allowed, k)
+        end
+        return allowed
+    end
+end
+
 SPECIALS['require-macros'] = function(ast, scope, parent)
     for i = 2, #ast do
-        local modname = ast[i];
-        local mod;
+        local modname = ast[i]
+        local mod
         if macroLoaded[modname] then
             mod = macroLoaded[modname]
         else
             local filename = assertCompile(searchModule(modname),
                                            modname .. " not found.", ast)
-            mod = dofile_fennel(filename, {env=makeCompilerEnv(ast, scope, parent)})
+            local env = makeCompilerEnv(ast, scope, parent)
+            mod = dofile_fennel(filename, {env=env,
+                                           allowedGlobals=macroGlobals(env)})
             macroLoaded[modname] = mod
         end
         for k, v in pairs(assertCompile(isTable(mod), 'expected ' .. modname ..
                                         ' module to be table', ast)) do
+            if allowedGlobals then table.insert(allowedGlobals, k) end
             scope.specials[k] = macroToSpecial(v)
         end
     end
@@ -1832,7 +1868,8 @@ local stdmacros = [===[
 }
 ]===]
 for name, fn in pairs(eval(stdmacros, {
-    env = makeCompilerEnv(nil, GLOBAL_SCOPE, {})
+    env = makeCompilerEnv(nil, GLOBAL_SCOPE, {}),
+    allowedGlobals = false,
 })) do
     SPECIALS[name] = macroToSpecial(fn)
 end

--- a/test.lua
+++ b/test.lua
@@ -194,7 +194,7 @@ local pass, fail, err = 0, 0, 0
 for name, tests in pairs(cases) do
     print("Running tests for " .. name .. "...")
     for code, expected in pairs(tests) do
-        local ok, res = pcall(fennel.eval, code)
+        local ok, res = pcall(fennel.eval, code, {allowedGlobals = false})
         if not ok then
             err = err + 1
             print(" Error: " .. res .. " in: ".. fennel.compile(code))
@@ -278,8 +278,6 @@ local macro_cases = {
     -- macros with mangled names
     ["(require-macros \"test-macros\")\
       (->1 9 (+ 2) (* 11))"]=121,
-    -- require-macros doesn't leak into new evaluation contexts
-    ["(let [(_ e) (pcall (fn [] (->1 8 (+ 2))))] (: e :match :global))"]="global",
     -- macros loaded in function scope shouldn't leak to other functions
     ["((fn [] (require-macros \"test-macros\") (global x1 (->1 99 (+ 31)))))\
       (pcall (fn [] (global x1 (->1 23 (+ 1)))))\
@@ -304,6 +302,10 @@ for code, expected in pairs(macro_cases) do
             pass = pass + 1
         end
     end
+end
+if pcall(fennel.eval, "(->1 1 (+ 4))", {allowedGlobals = false}) then
+    fail = fail + 1
+    print(" Expected require-macros not leak into next evaluation.")
 end
 
 local compile_failures = {


### PR DESCRIPTION
As discussed in #79.