### PR TITLE
Add destructuring for each and fn bindings.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1083,10 +1083,14 @@ SPECIALS['fn'] = function(ast, scope, parent)
             assertCompile(i == #argList, "expected vararg in last parameter position", ast)
             argNameList[i] = '...'
             fScope.vararg = true
-        elseif isSym(argList[i])
-            and argList[i][1] ~= "nil"
-            and not isMultiSym(argList[i][1]) then
+        elseif(isSym(argList[i]) and argList[i][1] ~= "nil"
+               and not isMultiSym(argList[i][1])) then
             argNameList[i] = declareLocal(argList[i], {}, fScope, ast)
+        elseif isTable(argList[i]) then
+            local raw = sym(gensym(scope))
+            argNameList[i] = declareLocal(raw, {}, fScope, ast)
+            destructure(argList[i], raw, ast, fScope, fChunk,
+                        { declaration = true, nomulti = true })
         else
             assertCompile(false, 'expected symbol for function parameter', ast)
         end
@@ -1302,14 +1306,26 @@ SPECIALS['each'] = function(ast, scope, parent)
     local binding = assertCompile(isTable(ast[2]), 'expected binding table', ast)
     local iter = table.remove(binding, #binding) -- last item is iterator call
     local bindVars = {}
+    local destructures = {}
     for _, v in ipairs(binding) do
-        assertCompile(isSym(v), 'expected iterator symbol', ast)
-        table.insert(bindVars, declareLocal(v, {}, scope, ast))
+        assertCompile(isSym(v) or isTable(v),
+                      'expected iterator symbol or table', ast)
+        if(isSym(v)) then
+            table.insert(bindVars, declareLocal(v, {}, scope, ast))
+        else
+            local raw = sym(gensym(scope))
+            destructures[raw] = v
+            table.insert(bindVars, declareLocal(raw, {}, scope, ast))
+        end
     end
     emit(parent, ('for %s in %s do'):format(
              table.concat(bindVars, ', '),
              tostring(compile1(iter, scope, parent, {nval = 1})[1])), ast)
     local chunk = {}
+    for raw, args in pairs(destructures) do
+        destructure(args, raw, ast, scope, chunk,
+                    { declaration = true, nomulti = true })
+    end
     compileDo(ast, scope, chunk, 3)
     emit(parent, chunk, ast)
     emit(parent, 'end', ast)

--- a/test.lua
+++ b/test.lua
@@ -172,6 +172,10 @@ local cases = {
         ["(let [[a b & c] [1 2 3 4 5]] (+ a (. c 2) (. c 3)))"]=10,
         -- all vars get flagged as var
         ["(var [a [b c]] [1 [2 3]]) (set a 2) (set c 8) (+ a b c)"]=12,
+        -- fn args
+        ["((fn dest [a [b c] [d]] (+ a b c d)) 5 [9 7] [2])"]=23,
+        -- each
+        ["(var x 0) (each [_ [a b] (ipairs [[1 2] [3 4]])] (set x (+ x (* a b)))) x"]=14,
     },
 
     loops = {


### PR DESCRIPTION
It works fine, but the output is somewhat less than ideal as it
introduces one level of unnecessary binding:

```clj
(each [_ [a b] (ipairs [[1 2] [3 4]])]
  (print (+ a b)))
```

```lua
for _, _0_0 in ipairs({{1, 2}, {3, 4}}) do
  local _1_ = _0_0 -- <- this bit here is redundant
  local a = _1_[1]
  local b = _1_[2]
  print((a + b))
end
```

I'm probably abusing `declareLocal` here; any advice on how I could
clean that up?

Fixes #85 