### PR TITLE
Allow globals from an environment when one is provided.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1577,9 +1577,10 @@ local function traceback(msg, start)
     return table.concat(lines, '\n')
 end
 
-local function currentGlobalNames()
+local function currentGlobalNames(env)
+    env = env or _G
     local names = {}
-    for k in pairs(_G) do table.insert(names, k) end
+    for k in pairs(env) do table.insert(names, k) end
     return names
 end
 
@@ -1588,7 +1589,7 @@ local function eval(str, options, ...)
     -- eval and dofile are considered "live" entry points, so we can assume
     -- that the globals available at compile time are a reasonable allowed list
     if options.allowedGlobals == nil then
-        options.allowedGlobals = currentGlobalNames()
+        options.allowedGlobals = currentGlobalNames(options.env)
     end
     local luaSource = compileString(str, options)
     local loader = loadCode(luaSource, options.env,
@@ -1599,7 +1600,7 @@ end
 local function dofile_fennel(filename, options, ...)
     options = options or {sourcemap = true}
     if options.allowedGlobals == nil then
-        options.allowedGlobals = currentGlobalNames()
+        options.allowedGlobals = currentGlobalNames(options.env)
     end
     local f = assert(io.open(filename, "rb"))
     local source = f:read("*all")
@@ -1615,7 +1616,7 @@ local function repl(options)
     -- This would get set for us when calling eval, but we want to seed it
     -- with a value that is persistent so it doesn't get reset on each eval.
     if opts.allowedGlobals == nil then
-        options.allowedGlobals = currentGlobalNames()
+        options.allowedGlobals = currentGlobalNames(opts.env)
     end
 
     local env = opts.env or setmetatable({}, {


### PR DESCRIPTION
When no `allowedGlobals` list is provided, the current behaviour is to use a list based on the globals in the current environment. This is confusing when the user has supplied an environment for the code to run in, as the globals from that environment won't be allowed by the compiler. This is compounded by the fact the `allowedGlobals` mechanism isn't documented.

I've made a change so that the `allowedGlobals` list is instead generated based on the environment the code is running in. If none is supplied, it works as it currently does. 

I ran `make ci` without any problems, and these changes are quite simple. Let me know if you have any feedback.