### PR TITLE
#! support (hashbang, shebang)

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1602,7 +1602,7 @@ local function dofile_fennel(filename, options, ...)
         options.allowedGlobals = currentGlobalNames(options.env)
     end
     local f = assert(io.open(filename, "rb"))
-    local source = f:read("*all")
+    local source = f:read("*all"):gsub("^#![^\n]*\n", "")
     f:close()
     options.filename = options.filename or filename
     return eval(source, options, ...)


### PR DESCRIPTION
This adds support for `#!`s by just stripping the first line of a file of fennel code if it starts with `#!`.

I was motivate to do this by #98.