### PR TITLE
Teach `fennel` vararg script args

### DIFF
--- a/fennel
+++ b/fennel
@@ -3,6 +3,7 @@
 local fennel_dir = arg[0]:match("(.-)[^\\/]+$")
 package.path = fennel_dir .. "?.lua;" .. package.path
 local fennel = require('fennel')
+local unpack = unpack or table.unpack
 
 local help = [[
 Usage: fennel [FLAG] [FILE]
@@ -21,9 +22,9 @@ local options = {
     sourcemap = true
 }
 
-local function dosafe(filename, opts, arg1)
+local function dosafe(filename, opts, args)
     local ok, val = xpcall(function()
-        return fennel.dofile(filename, opts, arg1)
+        return fennel.dofile(filename, opts, unpack(args))
     end, fennel.traceback)
     if not ok then
         print(val)
@@ -79,7 +80,7 @@ elseif arg[1] == "--compile" then
     end
 elseif #arg >= 1 and arg[1] ~= "--help" then
     local filename = table.remove(arg, 1) -- let the script have remaining args
-    dosafe(filename)
+    dosafe(filename, nil, arg)
 else
     print(help)
 end


### PR DESCRIPTION
This could be done simpler without the `args` arg, but `dosafe` didn't rely on closing over state before.