### PR TITLE
Allow stdin with --compile

### DIFF
--- a/fennel
+++ b/fennel
@@ -69,7 +69,7 @@ if arg[1] == "--repl" or #arg == 0 then
     fennel.repl(options)
 elseif arg[1] == "--compile" then
     for i = 2, #arg do
-        local f = assert(io.open(arg[i], "rb"))
+        local f = arg[i] == "-" and io.stdin or assert(io.open(arg[i], "rb"))
         options.filename=arg[i]
         local ok, val = xpcall(function()
             return fennel.compileString(f:read("*all"), options)


### PR DESCRIPTION
A tiny change to add the ability to compile Fennel code supplied on stdin to the `fennel` command.

Usage would be:
```
$ echo "(print (+ 1 2))" | fennel --compile -
return print((1 + 2))
```
or:
```
$ echo "(print :file-a)" > a.fnl
$ echo "(print :file-b)" > b.fnl
$ echo "(print :stdin)" | fennel --compile a.fnl - b.fnl 
return print("file-a")
return print("stdin")
return print("file-b")
```