### PR TITLE
Remove defn.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.1.0 / ??
 
+* Remove `defn` macro as it is redundant.
 * Add `doto` macro
 * Support newlines in strings
 * Prevent typos from accidentally referring to unknown globals

--- a/fennel.lua
+++ b/fennel.lua
@@ -1877,9 +1877,6 @@ local stdmacros = [===[
              (table.insert form elt))
            (table.insert form name)
            form))
- :defn (fn [name args ...]
-         (assert (sym? name) "defn: function names must be symbols")
-         (list (sym :fn) name args ...))
  :when (fn [condition body1 ...]
          (assert body1 "expected body")
          (list (sym 'if') condition

--- a/test-macros.fnl
+++ b/test-macros.fnl
@@ -6,6 +6,6 @@
           (set x elt))
         x)
  :defn1 (fn [name args ...]
-         (assert (sym? name) "defn: function names must be symbols")
+         (assert (sym? name) "defn1: function names must be symbols")
          (list (sym "global") name
                (list (sym "fn") args ...)))}

--- a/test.lua
+++ b/test.lua
@@ -354,8 +354,6 @@ local compile_failures = {
     ["()"]="expected a function to call",
     ["(789)"]="789.*cannot call literal value",
     ["(fn [] [...])"]="unexpected vararg",
-    -- compiler environment
-    ["(defn [:foo] [] nil)"]="defn.*function names must be symbols",
     -- line numbers
     ["(set)"]="Compile error in 'set' unknown:1: expected name and value",
     ["(let [b 9\nq (.)] q)"]="2: expected table argument",


### PR DESCRIPTION
I think we can get rid of this; if I had known that `fn` could be used the same way as `defn` then I would not have added it in the first place. Figure we should get all our breaking changes in before 0.1.0.

Any thoughts?