### PR TITLE
Only save off new locals when it is safe to do so.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1720,9 +1720,11 @@ local function repl(options)
         for name in pairs(env.___replLocals___) do
             table.insert(splicedSource, 1, bind:format(name, name))
         end
-        -- save off new locals at the end
-        if(#splicedSource > 1) then
-            table.insert(splicedSource, #splicedSource, saveSource)
+        -- save off new locals at the end - if safe to do so (i.e. last line is a return)
+        if (string.match(splicedSource[#splicedSource], "^ *return .*$")) then
+            if (#splicedSource > 1) then
+                table.insert(splicedSource, #splicedSource, saveSource)
+            end
         end
         return table.concat(splicedSource, "\n")
     end


### PR DESCRIPTION
This adds a check if the last line of `luaSource` is a `return` statement, if so then the `saveSource` code is injected otherwise it isn't.

This feels like a bit of a hack, but it works! 

Fixes #118 
