### PR TITLE
Add -?> & -?>> AKA the thread maybe macros.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0 / ???
 
+* Add `-?>` and `-?>>` macros
 * Support key/value tables when destructuring
 * Add `match` macro for pattern matching
 * Add optional GNU readline support for repl

--- a/fennel.lua
+++ b/fennel.lua
@@ -2042,6 +2042,28 @@ local stdmacros = [===[
            (table.insert elt x)
            (set x elt))
          x)
+ "-?>" (fn [val ...]
+         (if (= 0 (# [...]))
+             val
+             (let [els [...]
+                   el (table.remove els 1)
+                   tmp (gensym)]
+               (table.insert el 2 tmp)
+               (list (sym :let) [tmp val]
+                     (list (sym :if) tmp
+                           (list (sym :-?>) el (unpack els))
+                           tmp)))))
+ "-?>>" (fn [val ...]
+          (if (= 0 (# [...]))
+              val
+              (let [els [...]
+                    el (table.remove els 1)
+                    tmp (gensym)]
+                (table.insert el tmp)
+                (list (sym :let) [tmp val]
+                      (list (sym :if) tmp
+                            (list (sym :-?>>) el (unpack els))
+                            tmp)))))
  :doto (fn [val ...]
          (let [name (gensym)
                form (list (sym :let) [name val])]

--- a/reference.md
+++ b/reference.md
@@ -387,7 +387,7 @@ Example:
 
 ## Other
 
-### `->` and `->>` threading macros
+### `->`, `->>`, `-?>` and `-?>>` threading macros
 
 The `->` macro takes its first value and splices it into the second
 form as the first argument. The result of evaluating the second form
@@ -404,6 +404,26 @@ Example:
 
 The `->>` macro works the same, except it splices it into the last
 position of each form instead of the first.
+
+`-?>` and `-?>>`, the thread maybe macros, are similar to `->` & `->>`
+but they also do falsey checking after the evaluation of each threaded
+form. If the result is falsey then the threading stops and the result
+is returned. `-?>` splices the threaded value as the first argument,
+like `->`, and `-?>>` splices it into the last position, like `->>`.
+
+This example shows how to use them to avoid accidentally indexing a
+nil value:
+
+```
+(-?> {:a {:b {:c 42}}}
+     (. :a)
+     (. :missing)
+     (. :c)) ; -> nil
+(-?>> :a
+      (. {:a :b})
+      (. {:b :missing})
+      (. {:c 42})) ; -> nil
+```
 
 Note that these have nothing to do with "threads" used for
 concurrency; they are named after the thread which is used in

--- a/test.lua
+++ b/test.lua
@@ -299,6 +299,10 @@ fennel.eval([[(eval-compiler
 local macro_cases = {
     -- built-in macros
     ["(let [x [1]] (doto x (table.insert 2) (table.insert 3)) (table.concat x))"]="123",
+    ["(-?> {:a {:b {:c :z}}} (. :a) (. :b) (. :c))"]="z",
+    ["(-?> {:a {:b {:c :z}}} (. :a) (. :missing) (. :c))"]=nil,
+    ["(-?>> :w (. {:w :x}) (. {:x :y}) (. {:y :z}))"]="z",
+    ["(-?>> :w (. {:w :x}) (. {:x :missing}) (. {:y :z}))"]=nil,
     -- just a boring old set+fn combo
     ["(require-macros \"test-macros\")\
       (defn1 hui [x y] (global z (+ x y))) (hui 8 4) z"]=12,


### PR DESCRIPTION
This transforms the threaded forms in to nested ifs, which has the advantage of early exit. But the disadvantage of potentially creating a deeply nested Fennel AST & Lua code.

We could (and I notice that this is what Clojure's `some->` does) transform this in to a "flat" let instead.

If you like this approach I'll tweak it for the "thread last maybe" `-?>>` macro. If not, I'm happy to rewrite it.