### PR TITLE
Address #116

### DIFF
--- a/fennel
+++ b/fennel
@@ -69,7 +69,9 @@ local function tryReadline(opts)
         function opts.readChunk(parserState)
             local prompt = parserState.stackSize > 0 and '.. ' or '>> '
             local str = readline.readline(prompt)
-            return str
+            if str then
+                return str .. "\n"
+            end
         end
     end
 end

--- a/fennel.lua
+++ b/fennel.lua
@@ -1922,7 +1922,7 @@ SPECIALS['eval-compiler'] = function(ast, scope, parent)
     ast[1] = sym('do')
     local luaSource = compile(ast, { scope = makeScope(COMPILER_SCOPE) })
     ast[1] = oldFirst
-    local loader = loadCode(luaSource, makeCompilerEnv(ast, scope, parent))
+    local loader = loadCode(luaSource, wrapEnv(makeCompilerEnv(ast, scope, parent)))
     loader()
 end
 


### PR DESCRIPTION
I have tried to fix #116 by adding a function wrapEnv which wraps a normal lua table that maps fennel identifiers to their mangled versions. This means that we can pass this wrapped environment to setfenv, while the original table will behave as expected when observe externally.

Fox example, look at the new  makeCompilerEnv and notice that we no longer need to mangle identifiers manually. This also has the benefit that dynamically declared globals will properly be passed into the original environment table.

```lua
local fennel = require('fennel')
local env = {["a-value"] = 12}
fennel.eval("(print a-value)", { env = env })
-- Prints 12
fennel.eval("(global my-global 123)", { env = env })
print(env["my-global"])
-- Prints 123
```

I would like some review on this because this may have consequences for existing code or use-cases.