### PR TITLE
Allow mangled globals in strict mode

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1739,7 +1739,10 @@ end
 
 local function currentGlobalNames(env)
     local names = {}
-    for k in pairs(env or _G) do table.insert(names, k) end
+    for k in pairs(env or _G) do
+       k = globalUnmangling(k)
+       table.insert(names, k)
+    end
     return names
 end
 

--- a/test.lua
+++ b/test.lua
@@ -550,5 +550,15 @@ if(not pcall(fennel.eval, "(each [k (pairs _G)] (tset tbl k true))", {env = g})
     print(" Expected wrapped _G to support env iteration.")
 end
 
+do
+    local e = {}
+    if (not pcall(fennel.eval, "(global x-x 42)", {env = e})
+        or not pcall(fennel.eval, "x-x", {env = e})) then
+        fail = fail + 1
+        print(" Expected mangled globals to be accessible across eval invocations.")
+    end
+end
+
+
 print(string.format("\n%s passes, %s failures, %s errors.", pass, fail, err))
 if(fail > 0 or err > 0) then os.exit(1) end


### PR DESCRIPTION
When inferring the allowed globals for the compilation environment we should include mangled names so that mangled identifiers don't get rejected as unknown globals.

This PR includes a regression test to illustrate the problem I want to fix.