### PR TITLE
arity check for tset special form

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1227,6 +1227,8 @@ end
 
 -- For setting items in a table
 SPECIALS['tset'] = function(ast, scope, parent)
+    assertCompile(#ast > 3,
+                  ('tset form needs table, key, and value'), ast)
     local root = compile1(ast[2], scope, parent, {nval = 1})[1]
     local keys = {}
     for i = 3, #ast - 1 do


### PR DESCRIPTION
This adds a compile time arity check for the tset special form, to improve the error message when too few args are provided.

before:
```
(cmd)>> (local t {})

(cmd)>> (tset t :a)
Bad code generated - likely a bug with the compiler:
--- Generated Lua Start ---
local t = ___replLocals___['t']
t[] = "a"
local ___i___ = 1
while true do
 local name, value = debug.getlocal(1, ___i___)
 if(name and name ~= "___i___") then
 ___replLocals___[name] = value
 ___i___ = ___i___ + 1
 else break end end
return nil
--- Generated Lua End ---
Lua Compile error: /usr/local/share/lua/5.2/fennel.lua:56: [string "local t = ___replLocals___['t']..."]:2: unexpected symbol near ']'
```

after:
```
(cmd)>> (local t {})

(cmd)>> (tset t :a)
Compile error: Compile error in 'tset' unknown:2: tset form needs table, key, and value
```