### PR TITLE
Check for fishy redefinitions that might be bad

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -928,6 +928,9 @@ local function destructure(to, from, ast, scope, parent, opts)
     -- Recursive auxiliary function
     local function destructure1(left, rightexprs, up1)
         if isSym(left) and left[1] ~= "nil" then
+            -- Check if symbol will be over shadowed by special
+            assertCompile(not scope.specials[left[1]],
+                ("symbol %s may be overshadowed by a special form or macro"):format(left[1]), left)
             emit(parent, setter:format(getname(left, up1), exprs1(rightexprs)), left)
         elseif isTable(left) then -- table destructuring
             local s = gensym(scope)

--- a/test.lua
+++ b/test.lua
@@ -415,6 +415,11 @@ local compile_failures = {
     ["(let [t {:a 1}] (+ t.a BAD))"]="BAD",
     ["(each [k v (pairs {})] (BAD k v))"]="BAD",
     ["(global good (fn [] nil)) (good) (BAD)"]="BAD",
+    ["(global + 1)"]="overshadowed",
+    ["(global // 1)"]="overshadowed",
+    ["(global let 1)"]="overshadowed",
+    ["(global - 1)"]="overshadowed",
+    ["(let [global 1] 1)"]="overshadowed",
 }
 
 print("Running tests for compile errors...")


### PR DESCRIPTION
It was possible in Fennel to create bindings that may be 'over-shadowed' by a macro or special form.
When used in a function call, a binding that shares a name with a special form cannot be used, as use
in the function position will be interpreted by the compiler as a special form or macro.

```
(global x 1)
(let [let print] (let [x let] x))
```
The above code is an example where the symbol let appears 4 times. The first let is a macro name, and the second introduces a binding named let. The third invocation of let will again be a macro invocation, even though a binding named let was made. The fourth let will be bound to print as expected.

Such code is confusing and surprising, so in this pull request, the compiler disallows all such code.