### PR TITLE
Allow macros to detect sequence literals

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -527,6 +527,8 @@ and a metatable that the compiler uses to distinguish them. You can use
 * `list?` - is the argument a list?
 * `sym?` - is the argument a symbol?
 * `table?` - is the argument a non-list table?
+* `sequence?` - is the argument a non-list _sequential_ table (created
+  with `[]`, as opposed to `{}`)?
 * `varg?` - is this a `...` symbol which indicates var args?
 * `multi-sym?` - a multi-sym is a dotted symbol which refers to a table's field
 * `in-scope?` - does this symbol refer to a local in the current scope?


### PR DESCRIPTION
This commit tags sequence literals (e.g., `[:a :b :c]`) with a specific metatable `SEQUENCE_MT`, and provides a `sequence?` function to macros to detect sequence literals. This allows macros which create data structures other than Lua tables from literals to see the source code's intent when deciding what kind of structure to create - even in the otherwise-thorny case of the empty table (`[]` vs. `{}`). My motivation for this change is working with Fengari - JS has distinct Object/Array types, so in order for a macro which uses a literal to create a JS structure, we have to be able to distinguish between the two kinds of literals, which without this change are not perfectly distinguishable.