### PR TITLE
add readline completion to REPL

### DIFF
--- a/fennel
+++ b/fennel
@@ -83,7 +83,17 @@ local function tryReadline(opts)
                 return str .. "\n"
             end
         end
-    end
+
+        -- completer is registered by the repl, until then returns empty list
+        local completer
+        function opts.registerCompleter(replCompleter)
+          completer = replCompleter
+        end
+        local function replCompleter(text, from, to)
+          if completer then return completer(text, from, to) else return {} end
+        end
+        readline.set_complete_function(replCompleter)
+      end
 end
 
 if arg[1] == "--repl" or #arg == 0 then

--- a/fennel.lua
+++ b/fennel.lua
@@ -1994,7 +1994,7 @@ local function repl(options)
         local function addMatchesFromGen(next, param, state)
           for k in next, param, state do
             if #matches >= 40 then break -- cap completions at 40 to avoid overwhelming output
-            elseif inputFragment == k:sub(0, #inputFragment) then table.insert(matches, k) end
+            elseif inputFragment == k:sub(0, #inputFragment):lower() then table.insert(matches, k) end
           end
         end
         addMatchesFromGen(pairs(env._ENV or env._G or {}))


### PR DESCRIPTION
# Add readline completion to REPL
## Summary
Initial implementation adding input completion to the REPL! In the default REPL, it will work when `readline.lua` is present and [fennel](fennel) is able to successfully load it. It's also possible to use this update to add readline support to other uses of `fennel.repl`, including nrepl.

## Using options.registerCompleter

For a usage example, see [code added to fennel cli](https://github.com/jaawerth/Fennel/blob/e4fdb0acaf94d22afb5fd39e2d6278fd10cbcccd/fennel#L87-L96).

The `replCompleter` function is defined in fennel.lua, as it needs access to the contents therein. To make it usable externally, it will look for a `registerCompleter` callback passed in the options, and if found run `options.registerCompleter(replCompleter)`.

Completion can be added to nrepl and other non-readline REPLs by providing an `options.registerCompleter` function that accepts replCompleter and invokes it with `replCompleter(inputText, from, to)`, where `from` and `to` are the same as defined in [readline.lua's docs](http://www.pjb.com.au/comp/lua/readline.html#custom) under `set_complete_function`, and are used to slice the input text based on position and is used by `string.sub` in `replCompleter`.

## Documentation?

We can add this to the docs if we want it to be a supported API, but I left it out for now.
