### PR TITLE
Destructuring shorthand for variables named the same as keys

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1007,7 +1007,7 @@ local function destructure(to, from, ast, scope, parent, opts)
                     destructure1(left[k+1], {subexpr}, left)
                     return
                 else
-                    if type(k) == "string" and tostring(v) == ":" then v = sym(k) end
+                    if isSym(k) and tostring(k) == ":" and isSym(v) then k = tostring(v) end
                     if type(k) ~= "number" then k = serializeString(k) end
                     local subexpr = expr(('%s[%s]'):format(s, k), 'expression')
                     destructure1(v, {subexpr}, left)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1007,6 +1007,7 @@ local function destructure(to, from, ast, scope, parent, opts)
                     destructure1(left[k+1], {subexpr}, left)
                     return
                 else
+                    if type(k) == "string" and tostring(v) == ":" then v = sym(k) end
                     if type(k) ~= "number" then k = serializeString(k) end
                     local subexpr = expr(('%s[%s]'):format(s, k), 'expression')
                     destructure1(v, {subexpr}, left)

--- a/test.lua
+++ b/test.lua
@@ -200,6 +200,8 @@ local cases = {
         ["(var x 0) (each [_ [a b] (ipairs [[1 2] [3 4]])] (set x (+ x (* a b)))) x"]=14,
         -- key/value destructuring
         ["(let [{:a x :b y} {:a 2 :b 4}] (+ x y))"]=6,
+        -- key/value destructuring with the same names
+        ["(let [{:a : :b :} {:a 3 :b 5}] (+ a b))"]=8,
         -- nesting k/v and sequential
         ["(let [{:a [x y z]} {:a [1 2 4]}] (+ x y z))"]=7,
         -- Local shadowing in let form

--- a/test.lua
+++ b/test.lua
@@ -201,7 +201,7 @@ local cases = {
         -- key/value destructuring
         ["(let [{:a x :b y} {:a 2 :b 4}] (+ x y))"]=6,
         -- key/value destructuring with the same names
-        ["(let [{:a : :b :} {:a 3 :b 5}] (+ a b))"]=8,
+        ["(let [{: a : b} {:a 3 :b 5}] (+ a b))"]=8,
         -- nesting k/v and sequential
         ["(let [{:a [x y z]} {:a [1 2 4]}] (+ x y z))"]=7,
         -- Local shadowing in let form


### PR DESCRIPTION
This change adds the following syntax:

```fennel
(let [tbl {:a-long-key-name :a-value}
      {: a-long-key-name} tbl]
  a-long-key-name) ;; => "a-value"
```

This is equivalent to the following code in the current version of Fennel:

```fennel
(let [tbl {:a-long-key-name :a-value}
      {:a-long-key-name a-long-key-name} tbl]
  a-long-key-name) ;; => "a-value"
```