### PR TITLE
Table literal shorthand for keys named the same as variables

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -304,6 +304,9 @@ local function parser(getbyte, filename)
                     end
                     val = {}
                     for i = 1, #last, 2 do
+                        if tostring(last[i]) == ":" and isSym(last[i + 1]) then
+                            last[i] = tostring(last[i + 1])
+                        end
                         val[last[i]] = last[i + 1]
                     end
                 end

--- a/test.lua
+++ b/test.lua
@@ -137,6 +137,8 @@ local cases = {
         ["(let [x 17] (. 17))"]=17,
         -- table lookup with literal
         ["(+ (. {:a 93 :b 4} :a) (. [1 2 3] 2))"]=95,
+        -- table lookup with literal using matching-key-and-variable shorthand
+        ["(let [k 5 t {: k}] t.k)"]=5,
         -- set works with multisyms
         ["(let [t {}] (set t.a :multi) (. t :a))"]="multi",
         -- set works on parent scopes


### PR DESCRIPTION
This change adds the following syntax:

```fennel
(let [a-long-key-name :a-value
      tbl {: a-long-key-name}]
  tbl.a-long-key-name) ;; => "a-value"
```

This is equivalent to the following code in the current version of Fennel:

```fennel
(let [a-long-key-name :a-value
      tbl {:a-long-key-name a-long-key-name}]
  tbl.a-long-key-name) ;; => "a-value"
```
