### PR TITLE
Require whitespace before opening delimiter

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -237,6 +237,7 @@ local function parser(getbyte, filename)
 
         -- Dispatch when we complete a value
         local done, retval
+        local whitespaceSinceDispatch = true
         local function dispatch(v)
             if #stack == 0 then
                 retval = v
@@ -248,6 +249,7 @@ local function parser(getbyte, filename)
             else
                 table.insert(stack[#stack], v)
             end
+            whitespaceSinceDispatch = false
         end
 
         -- Throw nice error when we expect more characters
@@ -269,6 +271,9 @@ local function parser(getbyte, filename)
             -- Skip whitespace
             repeat
                 b = getb()
+                if b and iswhitespace(b) then
+                    whitespaceSinceDispatch = true
+                end
             until not b or not iswhitespace(b)
             if not b then
                 if #stack > 0 then badend() end
@@ -280,6 +285,9 @@ local function parser(getbyte, filename)
                     b = getb()
                 until not b or b == 10 -- newline
             elseif type(delims[b]) == 'number' then -- Opening delimiter
+                if not whitespaceSinceDispatch then
+                    parseError('expected whitespace before opening delimiter ' .. string.char(b))
+                end
                 table.insert(stack, setmetatable({
                     closer = delims[b],
                     line = line,

--- a/fennel.lua
+++ b/fennel.lua
@@ -295,7 +295,7 @@ local function parser(getbyte, filename)
                     bytestart = byteindex
                 }, LIST_MT))
             elseif delims[b] then -- Closing delimiter
-                if #stack == 0 then parseError 'unexpected closing delimiter' end
+                if #stack == 0 then parseError('unexpected closing delimiter ' .. string.char(b)) end
                 local last = stack[#stack]
                 local val
                 if last.closer ~= b then

--- a/test.lua
+++ b/test.lua
@@ -464,6 +464,8 @@ local compile_failures = {
     ["(let [global 1] 1)"]="overshadowed",
     ["(fn global [] 1)"]="overshadowed",
     ["(match [1 2 3] [a & b c] nil)"]="rest argument in final position",
+    ["(x(y))"]="expected whitespace before opening delimiter %(",
+    ["(x[1 2])"]="expected whitespace before opening delimiter %[",
 }
 
 print("Running tests for compile errors...")

--- a/test.lua
+++ b/test.lua
@@ -420,7 +420,7 @@ end
 
 local compile_failures = {
     ["(f"]="expected closing delimiter %) in unknown:1",
-    ["\n\n(+))"]="unexpected closing delimiter in unknown:3",
+    ["\n\n(+))"]="unexpected closing delimiter %) in unknown:3",
     ["(fn)"]="expected vector arg list",
     ["(fn [12])"]="expected symbol for function parameter",
     ["(fn [:huh] 4)"]="expected symbol for function parameter",


### PR DESCRIPTION
Require whitespace before opening delimiters - disallows both the following cases:

```lisp
(local x #(+ 1 $1))
(local y #(2))
(x(y)) ; used to return 3, now fails
(x (y)) ; still returns 3

(local z #[1 2 ((or unpack table.unpack) $1)])
(z[3 4]) ; used to return [1 2 3 4], now fails
(z [3 4]) ; still returns [1 2 3 4]
```

The other commit just adds the closing delimiter to the "uhexpected closing delimiter" error message.