### PR TITLE
Pattern match guards

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0 / ??
 
+* Add support for guard clauses with `:?` in pattern matches.
 * Support completion in repl when `readline.lua` is available.
 * Add `--globals` and `--globals-only` options to launcher script.
 * Remove `luaexpr` and `luastatement` for a single `lua` special.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0 / ??
 
-* Add support for guard clauses with `:?` in pattern matches.
+* Add support for guard clauses with `?` in pattern matches.
 * Support completion in repl when `readline.lua` is available.
 * Add `--globals` and `--globals-only` options to launcher script.
 * Remove `luaexpr` and `luastatement` for a single `lua` special.

--- a/fennel.lua
+++ b/fennel.lua
@@ -2291,6 +2291,14 @@ local stdmacros = [===[
               (values (if (: (tostring pattern) :find "^?")
                           true `(~= @(sym :nil) @val))
                       [pattern val]))
+          ;; guard clause
+          (and (list? pattern) (= :? (. pattern 2)))
+          (let [(condition bindings) (match-pattern vals (. pattern 1)
+                                                    unifications)]
+            (values `(let @bindings
+                       (and @(select 3 (unpack pattern)) @condition))
+                    bindings))
+
           ;; multi-valued patterns (represented as lists)
           (list? pattern)
           (let [condition `(and)

--- a/fennel.lua
+++ b/fennel.lua
@@ -2333,7 +2333,7 @@ local stdmacros = [===[
                           true `(not= ,(sym :nil) ,val))
                       [pattern val]))
           ;; guard clause
-          (and (list? pattern) (= :? (. pattern 2)))
+          (and (list? pattern) (sym? (. pattern 2)) (= :? (tostring (. pattern 2))))
           (let [(pcondition bindings) (match-pattern vals (. pattern 1)
                                                      unifications)
                 condition `(and ,pcondition)]

--- a/fennel.lua
+++ b/fennel.lua
@@ -2293,11 +2293,12 @@ local stdmacros = [===[
                       [pattern val]))
           ;; guard clause
           (and (list? pattern) (= :? (. pattern 2)))
-          (let [(condition bindings) (match-pattern vals (. pattern 1)
-                                                    unifications)]
-            (values `(let @bindings
-                       (and @(select 3 (unpack pattern)) @condition))
-                    bindings))
+          (let [(pcondition bindings) (match-pattern vals (. pattern 1)
+                                                     unifications)
+                condition `(and @pcondition)]
+            (for [i 3 (# pattern)] ; splice in guard clauses
+              (table.insert condition (. pattern i)))
+            (values `(let @bindings @condition) bindings))
 
           ;; multi-valued patterns (represented as lists)
           (list? pattern)

--- a/reference.md
+++ b/reference.md
@@ -144,13 +144,13 @@ or specific value. In these cases you can use guard clauses:
 
 ```lisp
 (match [91 12 53]
-  ([a b c] :? (= 5 a)) :will-not-match
-  ([a b c] :? (= 0 (math.fmod (+ a b c) 2)) (= 91 a)) c) ; -> 53
+  ([a b c] ? (= 5 a)) :will-not-match
+  ([a b c] ? (= 0 (math.fmod (+ a b c) 2)) (= 91 a)) c) ; -> 53
 ```
 
 In this case the pattern should be wrapped in parens (like when
 matching against multiple values) but the second thing in the parens
-is the `:?` marker. Each form following this marker is a condition;
+is the `?` symbol. Each form following this marker is a condition;
 all the conditions must evaluate to true for that pattern to match.
 
 (Note that Lua also has "patterns" which are matched against strings

--- a/reference.md
+++ b/reference.md
@@ -137,7 +137,21 @@ value will not match:
 ```
 
 There is a special case for `_`; it is never bound and always acts as
-a wildcard.
+a wildcard. If no clause matches, it returns nil.
+
+Sometimes you need to match on something more general than a structure
+or specific value. In these cases you can use guard clauses:
+
+```lisp
+(match [91 12 53]
+  ([a b c] :? (= 5 a)) :will-not-match
+  ([a b c] :? (= 0 (math.fmod (+ a b c) 2)) (= 91 a)) c) ; -> 53
+```
+
+In this case the pattern should be wrapped in parens (like when
+matching against multiple values) but the second thing in the parens
+is the `:?` marker. Each form following this marker is a condition;
+all the conditions must evaluate to true for that pattern to match.
 
 (Note that Lua also has "patterns" which are matched against strings
 similar to how regular expressions work in other languages; these are

--- a/test.lua
+++ b/test.lua
@@ -343,16 +343,16 @@ local cases = {
         ["(match [1] [a & b] (# b))"]=0,
         -- guard clause
         ["(match {:sieze :him} \
-            (tbl :? (. tbl :no)) :no \
-            (tbl :? (. tbl :sieze)) :siezed)"]="siezed",
+            (tbl ? (. tbl :no)) :no \
+            (tbl ? (. tbl :sieze)) :siezed)"]="siezed",
         -- multiple guard clauses
         ["(match {:sieze :him} \
-            (tbl :? tbl.sieze tbl.no) :no \
-            (tbl :? tbl.sieze (= tbl.sieze :him)) :siezed2)"]="siezed2",
+            (tbl ? tbl.sieze tbl.no) :no \
+            (tbl ? tbl.sieze (= tbl.sieze :him)) :siezed2)"]="siezed2",
         -- guards with patterns inside
         ["(match [{:sieze :him} 5] \
-            ([f 4] :? f.sieze (= f.sieze :him)) 4\
-            ([f 5] :? f.sieze (= f.sieze :him)) 5)"]=5,
+            ([f 4] ? f.sieze (= f.sieze :him)) 4\
+            ([f 5] ? f.sieze (= f.sieze :him)) 5)"]=5,
         ["(match [1] [a & b] (length b))"]=0,
     }
 }

--- a/test.lua
+++ b/test.lua
@@ -327,6 +327,18 @@ local cases = {
         -- rest args
         ["(match [1 2 3] [a & b] (+ a (. b 1) (. b 2)))"]=6,
         ["(match [1] [a & b] (# b))"]=0,
+        -- guard clause
+        ["(match {:sieze :him} \
+            (tbl :? (. tbl :no)) :no \
+            (tbl :? (. tbl :sieze)) :siezed)"]="siezed",
+        -- multiple guard clauses
+        ["(match {:sieze :him} \
+            (tbl :? tbl.sieze tbl.no) :no \
+            (tbl :? tbl.sieze (= tbl.sieze :him)) :siezed)"]="siezed",
+        -- guards with patterns inside
+        ["(match [{:sieze :him} 5] \
+            ([f 4] :? f.sieze (= f.sieze :him)) 4\
+            ([f 5] :? f.sieze (= f.sieze :him)) 5)"]=5,
     }
 }
 

--- a/test.lua
+++ b/test.lua
@@ -334,7 +334,7 @@ local cases = {
         -- multiple guard clauses
         ["(match {:sieze :him} \
             (tbl :? tbl.sieze tbl.no) :no \
-            (tbl :? tbl.sieze (= tbl.sieze :him)) :siezed)"]="siezed",
+            (tbl :? tbl.sieze (= tbl.sieze :him)) :siezed2)"]="siezed2",
         -- guards with patterns inside
         ["(match [{:sieze :him} 5] \
             ([f 4] :? f.sieze (= f.sieze :him)) 4\

--- a/test.lua
+++ b/test.lua
@@ -276,9 +276,9 @@ local cases = {
         ["(macros {:plus (fn [x y] `(+ @x @y))}) (plus 9 9)"]=18,
         -- Vararg in quasiquote
         ["(macros {:x (fn [] `(fn [...] (+ 1 1)))}) ((x))"]=2,
-	-- Threading macro with single function, with and without parens
-	["(-> 1234 (string.reverse) (string.upper))"]="4321",
-	["(-> 1234 string.reverse string.upper)"]="4321"
+        -- Threading macro with single function, with and without parens
+        ["(-> 1234 (string.reverse) (string.upper))"]="4321",
+        ["(-> 1234 string.reverse string.upper)"]="4321"
     },
     match = {
         -- basic literal


### PR DESCRIPTION
This allows pattern match clauses to include guard expressions which will prevent them from matching when they evaluate to false/nil.

Example:
```lisp
(match [91 12 53]
  ([a b c] ? (= 5 a)) :will-not-match
  ([a b c] ? (= 0 (math.fmod (+ a b c) 2)) (= 91 a)) c) ; -> 53
```

The pattern consists of parens wrapping a regular pattern, followed by a `?` symbol followed by one or more guard expressions. This seems to conflict with the use of parens for multi-valued patterns, but it should be distinct for two reasons: the `?` symbol, but also the fact that the guard expressions will also have parens in them, and multi-valued patterns can never have parens inside parens.

I believe this makes the pattern matching system a fair bit more useful. I'm not completely sold on the use of the `?` symbol; I had `:?` before but I think the symbol is better? Open to suggestions for alternatives here.

![guards guards](https://images-na.ssl-images-amazon.com/images/I/61yBOM6eLaL.jpg)