### PR TITLE
Make _ match nil in the match macro

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -2327,11 +2327,11 @@ local stdmacros = [===[
           (values `(= ,(. unifications (tostring pattern)) ,val) [])
           ;; bind a fresh local
           (sym? pattern)
-          (do (if (not= (tostring pattern) "_")
-                  (tset unifications (tostring pattern) val))
-              (values (if (: (tostring pattern) :find "^?")
-                          true `(not= ,(sym :nil) ,val))
-                      [pattern val]))
+          (let [wildcard? (= (tostring pattern) "_")]
+            (if (not wildcard?) (tset unifications (tostring pattern) val))
+            (values (if (or wildcard? (: (tostring pattern) :find "^?"))
+                        true `(not= ,(sym :nil) ,val))
+                    [pattern val]))
           ;; guard clause
           (and (list? pattern) (sym? (. pattern 2)) (= :? (tostring (. pattern 2))))
           (let [(pcondition bindings) (match-pattern vals (. pattern 1)

--- a/test.lua
+++ b/test.lua
@@ -338,6 +338,7 @@ local cases = {
         ["(match [1 2 [[1]]] [x y [z]] (. z 1))"]=1,
         -- _ wildcard
         ["(match [1 2] [_ _] :wildcard)"]="wildcard",
+        ["(match nil _ :yes nil :no)"]="yes",
         -- rest args
         ["(match [1 2 3] [a & b] (+ a (. b 1) (. b 2)))"]=6,
         ["(match [1] [a & b] (# b))"]=0,


### PR DESCRIPTION
Fixes part of #161. The other case mentioned in that issue is potentially a wontfix, as an existing way to use guard clauses with `nil` already exists.