### PR TITLE
Make multisyms work correctly in match macro

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -480,6 +480,9 @@ end
 -- from normal symbols is that they cannot be declared local, and
 -- they may have side effects on invocation (metatables)
 local function isMultiSym(str)
+    if isSym(str) then
+        return isMultiSym(tostring(str))
+    end
     if type(str) ~= 'string' then return end
     local parts = {}
     for part in str:gmatch('[^%.]+') do
@@ -2317,9 +2320,11 @@ local stdmacros = [===[
     ;; know we're either in a multi-valued clause (in which case we know the #
     ;; of vals) or we're not, in which case we only care about the first one.
     (let [[val] vals]
-      (if (and (sym? pattern) ; unification with outer locals (or nil)
-               (or (in-scope? pattern)
-                   (= :nil (tostring pattern))))
+      (if (or (and (sym? pattern) ; unification with outer locals (or nil)
+                   (or (in-scope? pattern)
+                       (= :nil (tostring pattern))))
+              (and (multi-sym? pattern)
+                   (in-scope? (. (multi-sym? pattern) 1))))
           (values `(= ,val ,pattern) [])
           ;; unify a local we've seen already
           (and (sym? pattern)

--- a/test.lua
+++ b/test.lua
@@ -354,6 +354,8 @@ local cases = {
             ([f 4] ? f.sieze (= f.sieze :him)) 4\
             ([f 5] ? f.sieze (= f.sieze :him)) 5)"]=5,
         ["(match [1] [a & b] (length b))"]=0,
+        -- multisym
+        ["(let [x {:y :z}] (match :z x.y 1 _ 0))"]=1,
     }
 }
 


### PR DESCRIPTION
Previously, the following code would fail due to a compilation error of `did not expect multisym`, instead of returning true:

```lisp
(let [x {:y :z}] (match :z x.y true _ false))
```

Now, the macro detects multisyms, checks if `x` is in scope (not `x.y`, which doesn't make sense to be in scope), and when possible adds a check that the value of the multisym pattern equals the value it's being matched against.

Additionally, `isMultiSym`/`multi-sym?` has been extended to work on AST symbols as well as strings.

Finally, a regression test has been added to `test.lua` that ensures the bug does not reappear.