### PR TITLE
Include special form

### DIFF
--- a/fennel
+++ b/fennel
@@ -19,7 +19,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --add-fennel-path  PATH : Add PATH to fennel.path for finding Fennel modules
   --globals G1[,G2...]    : Allow these globals in addition to standard ones
   --globals-only G1[,G2]  : Same as above, but exclude standard ones
-  --include               : Inline required modules in the output
+  --require-as-include    : Inline required modules in the output
 
   --eval SOURCE (-e)      : Evaluate source code and print the result
 
@@ -82,8 +82,8 @@ for i=#arg, 1, -1 do
     elseif arg[i] == "--globals-only" then
         allowGlobals(table.remove(arg, i+1))
         table.remove(arg, i)
-    elseif arg[i] == "--include" then
-        options.include = true
+    elseif arg[i] == "--require-as-include" then
+        options.requireAsInclude = true
         table.remove(arg, i)
     end
 end

--- a/fennel
+++ b/fennel
@@ -19,6 +19,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --add-fennel-path  PATH : Add PATH to fennel.path for finding Fennel modules
   --globals G1[,G2...]    : Allow these globals in addition to standard ones
   --globals-only G1[,G2]  : Same as above, but exclude standard ones
+  --include               : Inline required modules in the output
 
   --eval SOURCE (-e)      : Evaluate source code and print the result
 
@@ -80,6 +81,9 @@ for i=#arg, 1, -1 do
         table.remove(arg, i)
     elseif arg[i] == "--globals-only" then
         allowGlobals(table.remove(arg, i+1))
+        table.remove(arg, i)
+    elseif arg[i] == "--include" then
+        options.include = true
         table.remove(arg, i)
     end
 end

--- a/fennel.lua
+++ b/fennel.lua
@@ -2250,7 +2250,7 @@ SPECIALS['include'] = function(ast, scope, parent)
             for _, val in p do table.insert(forms, val) end
             e = compile1(forms, scope, parent, {nval = 1})[1]
         else
-            e = expr('(function()' .. s .. ' end)()')
+            e = expr('(function()' .. s .. ' end)()', 'expression')
         end
 
         local memoize = once(e, ast, scope, parent)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1690,6 +1690,7 @@ local function macroToSpecial(mac)
     end
 end
 
+local includeSpecial
 local function compile(ast, options)
     options = options or {}
     local oldGlobals = allowedGlobals
@@ -1697,6 +1698,7 @@ local function compile(ast, options)
     if options.indent == nil then options.indent = '  ' end
     local chunk = {}
     local scope = options.scope or makeScope(GLOBAL_SCOPE)
+    if options.include then scope.specials.require = includeSpecial end
     local exprs = compile1(ast, scope, chunk, {tail = true})
     keepSideEffects(exprs, chunk, nil, ast)
     allowedGlobals = oldGlobals
@@ -1796,6 +1798,7 @@ local function compileStream(strm, options)
     allowedGlobals = options.allowedGlobals
     if options.indent == nil then options.indent = '  ' end
     local scope = options.scope or makeScope(GLOBAL_SCOPE)
+    if options.include then scope.specials.require = includeSpecial end
     local vals = {}
     for ok, val in parser(strm, options.filename) do
         if not ok then break end
@@ -2220,7 +2223,7 @@ SPECIALS['require-macros'] = function(ast, scope, parent)
     addMacros(macroLoaded[modname], ast, scope, parent)
 end
 
-SPECIALS['include'] = function(ast, scope)
+includeSpecial = function (ast, scope)
     assertCompile(#ast == 2, 'expected one argument', ast)
     local mod = tostring(ast[2])
 

--- a/fennelview.fnl.lua
+++ b/fennelview.fnl.lua
@@ -161,10 +161,28 @@ local function _0_(self, v)
   end
 end
 put_value = _0_
+local function one_line(str)
+  return str:gsub("\n", " "):gsub("%[ ", "["):gsub(" %]", "]"):gsub("%{ ", "{"):gsub(" %}", "}"):gsub("%( ", "("):gsub(" %)", ")")
+end
 local function fennelview(root, options)
   local options = (options or {})
-  local inspector = {["max-ids"] = {}, appearances = count_table_appearances(root, {}), buffer = {}, depth = (options.depth or 128), ids = {}, indent = (options.indent or "  "), level = 0}
+  local inspector = inspector
+  local function _1_()
+    if options["one-line"] then
+      return ""
+    else
+      return "  "
+    end
+  end
+  inspector = {["max-ids"] = {}, appearances = count_table_appearances(root, {}), buffer = {}, depth = (options.depth or 128), ids = {}, indent = (options.indent or _1_()), level = 0}
   put_value(inspector, root)
-  return table.concat(inspector.buffer)
+  do
+    local str = table.concat(inspector.buffer)
+    if options["one-line"] then
+      return one_line(str)
+    else
+      return str
+    end
+  end
 end
 return fennelview


### PR DESCRIPTION
This pull request is for the `include` special form. The include special form reads a Fennel or Lua source file and splices it into the current Fennel compilation unit, usually either an output file a string that will be immediately compiled into a thunk. The semantics are similar to what was discussed on IRC, except that there is no pollution of lexical scope. This means that when used at the top level, `include` behaves almost exactly the same way as require from the user's point of view. `include` is also memoized for the current scope, so it can be used as a way of requiring dependencies.

For example, 

```clojure
(local fv (include "fennelview"))
(fv.fennelview [1 2 3 4])
```

Will embed the compiled Lua code of fennelview.fnl into the output. This can be used to generate portable scripts that are a single, self contained Lua source file.

`include` can also embed single file Lua dependencies perfectly into the generated source by wrapping their source in a function expression. `include` does not rewrite invocations of `require`, so any module loaded via `require` must be available at runtime.

## Caveats

The source file included by `include` can "see" symbols in the current scope where it was included. I don't believe that this is much of a problem, especially if `include` is used primarily at the beginning of files.

`include` can also be used to include multiple copies of the same code, as the memoization occurs only per scope. For example, the following will include the source code from `a.fnl` only once.

```clojure
(include "a.fnl")
(include "a.fnl")
(include "a.fnl")
```

But we can also include three copies of `a.fnl` by putting each `include` inside a do.

```clojure
(do (include "a.fnl"))
(do (include "a.fnl"))
(do (include "a.fnl"))
```