### PR TITLE
Prevent multiple returns from fennelview when one-line is true

### DIFF
--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -147,11 +147,13 @@
 
 
 (fn one-line [str]
-  (-> str
-      (: :gsub "\n" " ")
-      (: :gsub "%[ " "[") (: :gsub " %]" "]")
-      (: :gsub "%{ " "{") (: :gsub " %}" "}")
-      (: :gsub "%( " "(") (: :gsub " %)" ")")))
+  ;; save return value as local to ignore gsub's extra return value
+  (let [ret (-> str
+                (: :gsub "\n" " ")
+                (: :gsub "%[ " "[") (: :gsub " %]" "]")
+                (: :gsub "%{ " "{") (: :gsub " %}" "}")
+                (: :gsub "%( " "(") (: :gsub " %)" ")"))]
+    ret))
 
 (fn fennelview [root options]
   (let [options (or options {})


### PR DESCRIPTION
`string.gsub` returns multiple values, which were leaking out to the caller of `fennelview` when the `one-line` option was set to true.