### PR TITLE
Add metadata and docstrings

### DIFF
--- a/fennel
+++ b/fennel
@@ -20,6 +20,8 @@ Run fennel, a lisp programming language for the Lua runtime.
   --globals G1[,G2...]    : Allow these globals in addition to standard ones
   --globals-only G1[,G2]  : Same as above, but exclude standard ones
   --require-as-include    : Inline required modules in the output
+  --metadata              : Enable function metadata, even in compiled output (not recommended in production)
+  --no-metadata           : Disable function metadata, even in REPL
 
   --eval SOURCE (-e)      : Evaluate source code and print the result
 
@@ -84,6 +86,12 @@ for i=#arg, 1, -1 do
         table.remove(arg, i)
     elseif arg[i] == "--require-as-include" then
         options.requireAsInclude = true
+        table.remove(arg, i)
+    elseif arg[i] == "--metadata" then
+        options.useMetadata = true
+        table.remove(arg, i)
+    elseif arg[i] == "--no-metadata" then
+        options.useMetadata = false
         table.remove(arg, i)
     end
 end

--- a/fennel.lua
+++ b/fennel.lua
@@ -45,19 +45,6 @@ local LIST_MT = { 'LIST',
     end
 }
 local SEQUENCE_MT = { 'SEQUENCE' }
-local METADATA_MT = {
-  __mode = 'k',
-  __index = {
-    get = function(self, tgt, key)
-      if self[tgt] then return self[tgt][key] end
-      return nil
-    end,
-    set = function(self, tgt, key, value)
-      self[tgt] = self[tgt] or {}
-      self[tgt][key] = value
-      return tgt
-    end
-  }}
 
 -- Load code with an environment in all recent Lua versions
 local function loadCode(code, environment, filename)
@@ -768,7 +755,18 @@ end
 -- module-wide state for metadata
 -- create metadata table with weakly-referenced keys
 local function makeMetadata()
-  return setmetatable({}, METADATA_MT)
+    return setmetatable({}, {
+        __mode = 'k',
+        __index = {
+            get = function(self, tgt, key)
+                if self[tgt] then return self[tgt][key] end
+            end,
+            set = function(self, tgt, key, value)
+                self[tgt] = self[tgt] or {}
+                self[tgt][key] = value
+                return tgt
+            end
+        }})
 end
 
 local metadata = makeMetadata()
@@ -2246,7 +2244,6 @@ module.makeSearcher = function(options)
 end
 
 -- Add metadata and docstrings to fennel module
-module.makeMetadata = makeMetadata
 module.metadata = metadata
 module.doc = doc
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -1277,14 +1277,15 @@ SPECIALS['fn'] = function(ast, scope, parent)
 
     if rootOptions.useMetadata then
         local arglist = {}
-        for i, v in ipairs(argNameList) do arglist[i] = string.format("'%s'", v:gsub("'", "\\'")) end
+        for i, v in ipairs(argNameList) do arglist[i] = string.format('"%s"', v:gsub('"', '\\"')) end
         local metaFields = {
-            "'fnl/fn-name'", '"' .. fnName .. '"',
-            "'fnl/arglist'", '{' .. table.concat(arglist, ', ') .. '}',
+            '"fnl/fn-name"', '"' .. fnName .. '"',
+            '"fnl/arglist"', '{' .. table.concat(arglist, ', ') .. '}',
         }
         if docstring then
-            metaFields[5] = "'fnl/docstring'"
-            metaFields[6] = "'" .. docstring:gsub('\n', '\\n'):gsub('"', '\\"') .. "'"
+            metaFields[5] = '"fnl/docstring"'
+            metaFields[6] = '"' .. docstring:gsub('%s+$', '')
+                :gsub('\\', '\\\\'):gsub('\n', '\\n'):gsub('"', '\\"') .. '"'
         end
         local metaStr = 'require("fennel").metadata' --:set(%s, %s, "%s"):set(%s, %s, %s)'
         emit(parent, string.format('%s:setall(%s, %s)', metaStr, fnName, table.concat(metaFields, ', ')))

--- a/fennel.lua
+++ b/fennel.lua
@@ -765,13 +765,24 @@ local function makeMetadata()
                 self[tgt] = self[tgt] or {}
                 self[tgt][key] = value
                 return tgt
-            end
+            end,
+            setall = function(self, tgt, ...)
+                local kvLen, kvs = select('#', ...), {...}
+                if kvLen % 2 ~= 0 then error('metadata:setall() expected even numbero of k/v pairs') end
+                self[tgt] = self[tgt] or {}
+                for i = 1, kvLen, 2 do self[tgt][kvs[i]] = kvs[i + 1] end
+                return tgt
+            end,
         }})
 end
 
 local metadata = makeMetadata()
 local doc = function(tgt)
-  print(metadata:get(tgt, 'docstring'))
+    local fnName = metadata:get(tgt, 'fnl/fn-name')
+    local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or {}, ' ')
+    local docstring = (metadata:get(tgt, 'fnl/docstring') or ''):gsub('\n$', ''):gsub('\n', '\n  ')
+    print(string.format("(%s%s%s)\n  %s",
+        fnName, #arglist > 0 and ' ' or '', arglist, docstring))
 end
 -- Convert expressions to Lua string
 local function exprs1(exprs)
@@ -1244,17 +1255,8 @@ SPECIALS['fn'] = function(ast, scope, parent)
         end
     end
     if type(ast[index + 1]) == 'string' and index + 1 < #ast then
-      index = index + 1
-      docstring = ast[index]
-      if rootOptions.useMetadata then
-        docstring = docstring -- account for newlines and nested [[ ]] multiline strings
-                :gsub('\n', '\\n')
-                :gsub('[[](=*)[[]', '[=%1['):gsub('[]](=*)[]]', ']=%1]')
-        -- splice in argslist and format docstring contents
-        local argSep = #argNameList > 0 and ' ' or ''
-        local invokeStr = string.format("(%s%s%s)", fnName, argSep, table.concat(argNameList, ' '))
-        docstring = string.format("%s\n  %s", invokeStr, docstring)
-      end
+        index = index + 1
+        docstring = ast[index]
     end
     for i = index + 1, #ast do
         compile1(ast[i], fScope, fChunk, {
@@ -1273,10 +1275,19 @@ SPECIALS['fn'] = function(ast, scope, parent)
     emit(parent, fChunk, ast)
     emit(parent, 'end', ast)
 
-    if rootOptions.useMetadata and docstring then
-      local docSetter = string.format('require("fennel").metadata:set(%s, "docstring", [[%s]])',
-        fnName, docstring)
-      emit(parent, docSetter)
+    if rootOptions.useMetadata then
+        local arglist = {}
+        for i, v in ipairs(argNameList) do arglist[i] = string.format("'%s'", v:gsub("'", "\\'")) end
+        local metaFields = {
+            "'fnl/fn-name'", '"' .. fnName .. '"',
+            "'fnl/arglist'", '{' .. table.concat(arglist, ', ') .. '}',
+        }
+        if docstring then
+            metaFields[5] = "'fnl/docstring'"
+            metaFields[6] = "'" .. docstring:gsub('\n', '\\n'):gsub('"', '\\"') .. "'"
+        end
+        local metaStr = 'require("fennel").metadata' --:set(%s, %s, "%s"):set(%s, %s, %s)'
+        emit(parent, string.format('%s:setall(%s, %s)', metaStr, fnName, table.concat(metaFields, ', ')))
     end
 
     return expr(fnName, 'sym')

--- a/fennel.lua
+++ b/fennel.lua
@@ -1279,7 +1279,7 @@ SPECIALS['fn'] = function(ast, scope, parent)
     if rootOptions.useMetadata then
         local args = {}
         for i, v in ipairs(argList) do
-          args[i] =  isTable(argList[i]) and '"<table>"' or string.format('"%s"', tostring(argList[i]))
+          args[i] =  isTable(v) and '"<table>"' or string.format('"%s"', tostring(v))
         end
 
         local metaFields = {

--- a/fennel.lua
+++ b/fennel.lua
@@ -2482,7 +2482,10 @@ local stdmacros = [===[
            (let [args [...]
                  has-internal-name? (sym? (. args 1))
                  arglist (if has-internal-name? (. args 2) (. args 1))
-                 arity-check-position (if has-internal-name? 3 2)]
+                 docstring-position (if has-internal-name? 3 2)
+                 has-docstring? (and (> (# args) docstring-position)
+                                     (= :string (type (. args docstring-position))))
+                 arity-check-position (- 4 (if has-internal-name? 0 1) (if has-docstring? 0 1))]
              (fn check! [a]
                (if (table? a)
                    (each [_ a (pairs a)]

--- a/fennel.lua
+++ b/fennel.lua
@@ -778,10 +778,10 @@ end
 
 local metadata = makeMetadata()
 local doc = function(tgt)
-    local fnName = metadata:get(tgt, 'fnl/fn-name')
+    local fnName = metadata:get(tgt, 'fnl/fn-name') or '<fn:anonymous>'
     local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or {}, ' ')
-    local docstring = (metadata:get(tgt, 'fnl/docstring') or ''):gsub('\n$', ''):gsub('\n', '\n  ')
-    print(string.format("(%s%s%s)\n  %s",
+    local docstring = (metadata:get(tgt, 'fnl/docstring') or '<docstring:nil>'):gsub('\n$', ''):gsub('\n', '\n  ')
+    print(string.format("(%s%s%s)\n  %s\n",
         fnName, #arglist > 0 and ' ' or '', arglist, docstring))
 end
 -- Convert expressions to Lua string
@@ -1221,6 +1221,7 @@ SPECIALS['fn'] = function(ast, scope, parent)
     local fnName = isSym(ast[index])
     local isLocalFn
     local docstring
+    local fnNameString = fnName and tostring(fnName) or nil
     fScope.vararg = false
     if fnName and fnName[1] ~= 'nil' then
         isLocalFn = not isMultiSym(fnName[1])
@@ -1276,11 +1277,14 @@ SPECIALS['fn'] = function(ast, scope, parent)
     emit(parent, 'end', ast)
 
     if rootOptions.useMetadata then
-        local arglist = {}
-        for i, v in ipairs(argNameList) do arglist[i] = string.format('"%s"', v:gsub('"', '\\"')) end
+        local args = {}
+        for i, v in ipairs(argList) do
+          args[i] =  isTable(argList[i]) and '"<table>"' or string.format('"%s"', tostring(argList[i]))
+        end
+
         local metaFields = {
-            '"fnl/fn-name"', '"' .. fnName .. '"',
-            '"fnl/arglist"', '{' .. table.concat(arglist, ', ') .. '}',
+            '"fnl/fn-name"', fnNameString and '"' .. fnNameString .. '"' or 'nil',
+            '"fnl/arglist"', '{' .. table.concat(args, ', ') .. '}',
         }
         if docstring then
             metaFields[5] = '"fnl/docstring"'

--- a/fennel.lua
+++ b/fennel.lua
@@ -1205,7 +1205,7 @@ SPECIALS['values'] = values
 -- The fn special declares a function. Syntax is similar to other lisps;
 -- (fn optional-name [arg ...] (body))
 -- Further decoration such as docstrings, meta info, and multibody functions a possibility.
-SPECIALS['fn'] = function(ast, scope, parent, options)
+SPECIALS['fn'] = function(ast, scope, parent)
     local fScope = makeScope(scope)
     local fChunk = {}
     local index = 2

--- a/test.lua
+++ b/test.lua
@@ -610,7 +610,7 @@ for code, cond_msg in pairs(docstring_tests) do
   else
     if ok then
       fail = fail + 1
-      print(string.format("While testing %s,\n\tExpected %s to be %s", msg, expected, actual))
+      print(string.format("While testing %s,\n\tExpected %s to be %s", msg, actual, expected))
     else
       err = err + 1
       print(string.format("While testing %s, got error:\n\t%s", msg, actual))

--- a/test.lua
+++ b/test.lua
@@ -588,23 +588,32 @@ end
 
 print("Running tests for metadata and docstrings...")
 local docstring_tests = {
-    ['(doc (fn [] :A 1))'] = {'(_0_)\\n  A', 'no anonymous fn docstring mistmatch'},
-    ['(doc (λ [a] :B :ret-str))'] = {'(_0_ a)\\n  B', 'no anonymous lambda docstring mistmatch'},
+    ['(doc (fn foo [a] :C 1))'] = {'(foo a)\\n  C',
+      'for named functions, (doc fnname) shows name, args invocation, docstring'
+    },
+    ['(doc (λ foo [] :D 1))'] = {'(foo)\\n  D',
+      '(doc fnname) for named lambdas appear like named functions'
+    },
+    ['(doc (fn [] :A 1))'] = {'(<fn:anonymous>)\\n  A',
+      'anonymous functions show fn name in doc as <fn:anonymous>'
+    },
+    ['(doc (λ [a] :B :ret-str))'] = {'(<fn:anonymous> a)\\n  B',
+      'anonymous lambdas show fn name in doc as <fn:anonymous>'
+    },
     -- TODO: set correct fnName based on assigned var/prop name and use following test
     -- ['(local foo (fn [a] :C 1)) (doc foo)'] = {'(foo a)\\n  C', 'named/non-local fn docstring mismatch'},
-    ['(doc (fn foo [a] :C 1))'] = {'(foo a)\\n  C', 'no named fn docstring mismatch'},
-    ['(doc (λ foo [] :D 1))'] = {'(foo)\\n  D', 'no anonymous lambda docstring mistmatch'},
-    ['(doc (fn [] "return str"))'] = {
-        '(_0_)\\n  <nil>', "do not confuse returned string for docstring in undocumented fn"
+    ['(doc (fn [] "return str"))'] = {'(<fn:anonymous>)\\n  <docstring:nil>',
+      "should not confuse returned string for docstring in undocumented fn"
     },
-    ['(doc (fn ml [] "a\nmultiline\ndocstring" :result))'] = {
-        '(ml)\\n  a\\nmultiline\\ndocstring', 'multiline docstrings'
+    ['(doc (fn ml [] "a\nmultiline\ndocstring" :result))'] = {'(ml)\\n  a\\nmultiline\\ndocstring',
+        'multiline docstrings work correctly'
     },
     [ '(doc (fn ew [] "so \\"gross\\" \\\\\\\"I\\\\\\\" can\'t even" 1))' ] = {
-        '(ew)\\n  so "gross" \\"I\\" can\'t even', 'docstring escaping'
+        '(ew)\\n  so "gross" \\"I\\" can\'t even',
+        'docstrings should be auto-escaped'
     },
     ['(doc (fn foo! [-kebab- {:x x}] 1))'] = {
-        "(foo_21 _kebab_ _0_0)\\n  <nil>",
+        "(foo! -kebab- <table>)\\n  <docstring:nil>",
         "fn-name and args mangling",
     },
 }
@@ -614,8 +623,8 @@ for k, v in pairs(_ENV or _G) do doc_env[k] = v end
 doc_env.doc = function(fn)
     local fnName = fennel.metadata:get(fn, 'fnl/fn-name')
     local arglist = table.concat(fennel.metadata:get(fn, 'fnl/arglist') or '', ' ')
-    local docstring = fennel.metadata:get(fn, 'fnl/docstring') or '<nil>'
-    return string.format('(%s%s%s)\n  %s', fnName, #arglist > 0 and ' ' or '', arglist, docstring)
+    local docstring = fennel.metadata:get(fn, 'fnl/docstring') or '<docstring:nil>'
+    return string.format('(%s%s%s)\n  %s', fnName or '<fn:anonymous>', #arglist > 0 and ' ' or '', arglist, docstring)
 end
 doc_env.require = function(tgt)
     if tgt == "fennel" then return fennel else return require(tgt) end

--- a/test.lua
+++ b/test.lua
@@ -588,17 +588,24 @@ end
 
 print("Running tests for metadata and docstrings...")
 local docstring_tests = {
-    ['(doc (fn [] :A 1))'] = {'(_0_)\\n  A', 'anonymous fn docstring mistmatch'},
-    ['(doc (λ [a] :B :ret-str))'] = {'(_0_ a)\\n  B', 'anonymous lambda docstring mistmatch'},
+    ['(doc (fn [] :A 1))'] = {'(_0_)\\n  A', 'no anonymous fn docstring mistmatch'},
+    ['(doc (λ [a] :B :ret-str))'] = {'(_0_ a)\\n  B', 'no anonymous lambda docstring mistmatch'},
     -- TODO: set correct fnName based on assigned var/prop name and use following test
     -- ['(local foo (fn [a] :C 1)) (doc foo)'] = {'(foo a)\\n  C', 'named/non-local fn docstring mismatch'},
-    ['(doc (fn foo [a] :C 1))'] = {'(foo a)\\n  C', 'named fn docstring mismatch'},
-    ['(doc (λ foo [] :D 1))'] = {'(foo)\\n  D', 'anonymous lambda docstring mistmatch'},
+    ['(doc (fn foo [a] :C 1))'] = {'(foo a)\\n  C', 'no named fn docstring mismatch'},
+    ['(doc (λ foo [] :D 1))'] = {'(foo)\\n  D', 'no anonymous lambda docstring mistmatch'},
     ['(doc (fn [] "return str"))'] = {
         '(_0_)\\n  <nil>', "do not confuse returned string for docstring in undocumented fn"
     },
     ['(doc (fn ml [] "a\nmultiline\ndocstring" :result))'] = {
         '(ml)\\n  a\\nmultiline\\ndocstring', 'multiline docstrings'
+    },
+    [ '(doc (fn ew [] "so \\"gross\\" \\\\\\\"I\\\\\\\" can\'t even" 1))' ] = {
+        '(ew)\\n  so "gross" \\"I\\" can\'t even', 'docstring escaping'
+    },
+    ['(doc (fn foo! [-kebab- {:x x}] 1))'] = {
+        "(foo_21 _kebab_ _0_0)\\n  <nil>",
+        "fn-name and args mangling",
     },
 }
 
@@ -606,7 +613,7 @@ local doc_env = {}
 for k, v in pairs(_ENV or _G) do doc_env[k] = v end
 doc_env.doc = function(fn)
     local fnName = fennel.metadata:get(fn, 'fnl/fn-name')
-    local arglist = table.concat(fennel.metadata:get(fn, 'fnl/arglist') or '')
+    local arglist = table.concat(fennel.metadata:get(fn, 'fnl/arglist') or '', ' ')
     local docstring = fennel.metadata:get(fn, 'fnl/docstring') or '<nil>'
     return string.format('(%s%s%s)\n  %s', fnName, #arglist > 0 and ' ' or '', arglist, docstring)
 end
@@ -622,10 +629,10 @@ for code, cond_msg in pairs(docstring_tests) do
     else
         if ok then
             fail = fail + 1
-            print(string.format("While testing %s,\n\tExpected %s to be %s", msg, actual, expected))
+            print(string.format('While testing %s,\n\tExpected "%s" to be "%s"', msg, actual, expected))
         else
             err = err + 1
-            print(string.format("While testing %s, got error:\n\t%s", msg, actual))
+            print(string.format('While testing %s, got error:\n\t%s', msg, actual))
         end
     end
 end

--- a/test.lua
+++ b/test.lua
@@ -586,36 +586,48 @@ end
 
 ---- docstring tests ----
 
-print("Running tests for docstrings...")
+print("Running tests for metadata and docstrings...")
 local docstring_tests = {
-  ['(doc (fn [] :A 1))'] = {'(_0_)\\n  A', 'anonymous fn docstring mistmatch'},
-  ['(doc (λ [a] :B :ret-str))'] = {'(_0_ a)\\n  B', 'anonymous lambda docstring mistmatch'},
-  ['(doc (fn foo [a] :C 1))'] = {'(foo a)\\n  C', 'named fn docstring mismatch'},
-  ['(doc (λ foo [] :D 1))'] = {'(foo)\\n  D', 'anonymous lambda docstring mistmatch'},
-  ['(doc (fn [] "return str"))'] = {'<nil>', "do not confuse returned string for docstring in undocumented fn"},
+    ['(doc (fn [] :A 1))'] = {'(_0_)\\n  A', 'anonymous fn docstring mistmatch'},
+    ['(doc (λ [a] :B :ret-str))'] = {'(_0_ a)\\n  B', 'anonymous lambda docstring mistmatch'},
+    -- TODO: set correct fnName based on assigned var/prop name and use following test
+    -- ['(local foo (fn [a] :C 1)) (doc foo)'] = {'(foo a)\\n  C', 'named/non-local fn docstring mismatch'},
+    ['(doc (fn foo [a] :C 1))'] = {'(foo a)\\n  C', 'named fn docstring mismatch'},
+    ['(doc (λ foo [] :D 1))'] = {'(foo)\\n  D', 'anonymous lambda docstring mistmatch'},
+    ['(doc (fn [] "return str"))'] = {
+        '(_0_)\\n  <nil>', "do not confuse returned string for docstring in undocumented fn"
+    },
+    ['(doc (fn ml [] "a\nmultiline\ndocstring" :result))'] = {
+        '(ml)\\n  a\\nmultiline\\ndocstring', 'multiline docstrings'
+    },
 }
 
 local doc_env = {}
 for k, v in pairs(_ENV or _G) do doc_env[k] = v end
-doc_env.doc = function(fn) return fennel.metadata:get(fn, 'docstring') end
+doc_env.doc = function(fn)
+    local fnName = fennel.metadata:get(fn, 'fnl/fn-name')
+    local arglist = table.concat(fennel.metadata:get(fn, 'fnl/arglist') or '')
+    local docstring = fennel.metadata:get(fn, 'fnl/docstring') or '<nil>'
+    return string.format('(%s%s%s)\n  %s', fnName, #arglist > 0 and ' ' or '', arglist, docstring)
+end
 doc_env.require = function(tgt)
-  if tgt == "fennel" then return fennel else return require(tgt) end
+    if tgt == "fennel" then return fennel else return require(tgt) end
 end
 for code, cond_msg in pairs(docstring_tests) do
-  local expected, msg = (unpack or table.unpack)(cond_msg)
-  local ok, actual = pcall(fennel.eval, code, { useMetadata = true, env = doc_env })
-  actual = string.gsub(actual or '<nil>', '\n', '\\n')
-  if ok and expected == actual then
-    pass = pass + 1
-  else
-    if ok then
-      fail = fail + 1
-      print(string.format("While testing %s,\n\tExpected %s to be %s", msg, actual, expected))
+    local expected, msg = (unpack or table.unpack)(cond_msg)
+    local ok, actual = pcall(fennel.eval, code, { useMetadata = true, env = doc_env })
+    actual = string.gsub(actual or '<nil>', '\n', '\\n')
+    if ok and expected == actual then
+        pass = pass + 1
     else
-      err = err + 1
-      print(string.format("While testing %s, got error:\n\t%s", msg, actual))
+        if ok then
+            fail = fail + 1
+            print(string.format("While testing %s,\n\tExpected %s to be %s", msg, actual, expected))
+        else
+            err = err + 1
+            print(string.format("While testing %s, got error:\n\t%s", msg, actual))
+        end
     end
-  end
 end
 
 ---- misc one-off tests ----


### PR DESCRIPTION
resolves #154 

Implemented function metadata and docstring capability! The metadata table (which has weak keys, so it won't stop functions from being GC'd) can be extended further to store whatever you want in association with a function.

## Example
```clojure
Fennel 0.3.0 - Welcome to Fennel!
; regular function
>> (fn identity [x] "==> x" x)
#<function: 0x7feceff401e0>
>> (doc identity)
(identity x)
  ==> x

; higher-order function
>> (fn always [...]
.. "return a function that always returns everything passed in"
.. (let [args [...]] (fn [] "constant returner" (table.unpack args))))
#<function: 0x7fecf1027110>
>> (doc always)
(always ...)
  return a function that always returns everything passed in
>> (doc (always 1 2 3 4 5))
(_0_)
    constant returner

>> ((always 1 2 3 4 5))
1       2       3       4       5

; lambdas work, but the magic syntax does weird things to the generated invocation example
>> (λ greet [?greeting ?name]
.. "Say hi!"
.. (string.format "%s, %s" (or greeting :Hello) (or name :Stranger)))
#<function: 0x7fecefd5c830>
>> (greet)
"Hello, Stranger"
>> (doc greet)
(greet _3fgreeting _3fname)
  Say hi!
```
## Changes
### new flags/options
- `--metadata` and `--no-metadata` on the CLI
- `useMetadata` in the compiler API (defaults to false)
- REPL defaults `useMetadata` to true

### Metadata
Introduces table on `fennel.metadata` with weakly referenced keys. When metadata is enabled by passing `useMetadata = true` to the options (defaults to true in REPL), or passing the `--metadata` flag from the CLI, function and lambda declarations will automatically store this.

**NOTE:** This also means, when metadata enabled, that function/lambda declarations will automatically require `fennel`.

### `fennel.doc`

Introduces a new API function `fennel.doc` which will print a function's metadata (or `nil` if there is none, or if the function doesn't exist). This is set as a local in the REPL for convenience.

## Default behavior
### When compiling or running fennel
Docstrings are parsed out, but not set on metadata, because there is a performance hit to creating an entry in a weak metadata table for every function as well as the memory cost of storing it. As such, docstrings default to a NOOP.

### In the REPL
Metadata is enabled automatically, so values are stored in the metadata.

