### PR TITLE
Change doc to being a macro

### DIFF
--- a/fennel
+++ b/fennel
@@ -37,7 +37,8 @@ Run fennel, a lisp programming language for the Lua runtime.
   If ~/.fennelrc exists, loads it before launching a repl.]]
 
 local options = {
-    sourcemap = true
+    sourcemap = true,
+    moduleName = "fennel",
 }
 
 local function dosafe(filename, opts, args)

--- a/fennel
+++ b/fennel
@@ -155,8 +155,10 @@ if arg[1] == "--repl" or #arg == 0 then
         -- pass in options so fennerlrc can make changes to it
         dosafe(initFilename, options, options)
     end
-    print("Welcome to Fennel " .. fennel.version .. "!\n" ..
-              "Use (doc something) to view documentation.")
+    print("Welcome to Fennel " .. fennel.version .. "!")
+    if options.useMetadata ~= false then
+        print("Use (doc something) to view documentation.")
+    end
     fennel.repl(options)
 elseif arg[1] == "--compile" then
     for i = 2, #arg do

--- a/fennel
+++ b/fennel
@@ -38,7 +38,6 @@ Run fennel, a lisp programming language for the Lua runtime.
 
 local options = {
     sourcemap = true,
-    moduleName = "fennel",
 }
 
 local function dosafe(filename, opts, args)
@@ -104,8 +103,9 @@ for i=#arg, 1, -1 do
 end
 
 if not options.no_searcher then
-    table.insert((package.loaders or package.searchers),
-        fennel.make_searcher({correlate = true}))
+    local opts = {correlate = true}
+    for k,v in pairs(options) do opts[k] = v end
+    table.insert((package.loaders or package.searchers), fennel.make_searcher(opts))
 end
 
 -- Try to load readline library

--- a/fennel
+++ b/fennel
@@ -29,7 +29,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --version (-v)          : Show version
 
   Metadata is typically considered a development feature and is not recommended
-  for production.
+  for production. It is used for docstrings and enabled by default in the REPL.
 
   When not given a flag, runs the file given as the first argument.
   When given neither flag nor file, launches a repl.

--- a/fennel.lua
+++ b/fennel.lua
@@ -41,7 +41,7 @@ local LIST_MT = { 'LIST',
         for _, s in ipairs(self) do
             table.insert(strs, tostring(s))
         end
-        return '(' .. table.concat(strs, ', ', 1, #self) .. ')'
+        return '(' .. table.concat(strs, ' ', 1, #self) .. ')'
     end
 }
 local SEQUENCE_MT = { 'SEQUENCE' }

--- a/fennel.lua
+++ b/fennel.lua
@@ -2235,6 +2235,7 @@ local function repl(options)
     end
 
     opts.useMetadata = options.useMetadata ~= false
+    opts.moduleName = options.moduleName
     rootOptions = opts
 
     local env = opts.env and wrapEnv(opts.env) or setmetatable({}, {
@@ -2357,6 +2358,7 @@ local function repl(options)
                 source = srcstring,
                 scope = scope,
                 useMetadata = opts.useMetadata,
+                moduleName = opts.moduleName,
             })
             if not compileOk then
                 clearstream()
@@ -2429,7 +2431,8 @@ module.makeSearcher = function(options)
       -- this will propagate options from the repl but not from eval, because
       -- eval unsets rootOptions after compiling but before running the actual
       -- calls to require.
-      local opts = { useMetadata = rootOptions and rootOptions.useMetadata }
+      local opts = {}
+      for k,v in pairs(rootOptions or {}) do opts[k] = v end
       for k,v in pairs(options or {}) do opts[k] = v end
       local filename = searchModule(modulename)
       if filename then

--- a/fennel.lua
+++ b/fennel.lua
@@ -840,7 +840,7 @@ local doc = function(tgt, name)
     local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or
                                      {'#<unknown-arguments>'}, ' ')
     local docstring = (metadata:get(tgt, 'fnl/docstring') or
-                           '<docstring:nil>'):gsub('\n$', ''):gsub('\n', '\n  ')
+                           '#<undocumented>'):gsub('\n$', ''):gsub('\n', '\n  ')
     return string.format("(%s%s%s)\n  %s", name, #arglist > 0 and ' ' or '',
                          arglist, docstring)
 end

--- a/fennel.lua
+++ b/fennel.lua
@@ -2234,9 +2234,8 @@ local function repl(options)
         opts.allowedGlobals = currentGlobalNames(opts.env)
     end
 
-    if opts.useMetadata == nil then
-      opts.useMetadata = true
-    end
+    opts.useMetadata = options.useMetadata ~= false
+    rootOptions = opts
 
     local env = opts.env and wrapEnv(opts.env) or setmetatable({}, {
         __index = _ENV or _G
@@ -2426,8 +2425,11 @@ local function searchModule(modulename, pathstring)
 end
 
 module.makeSearcher = function(options)
-   return function(modulename)
-      local opts = {}
+    return function(modulename)
+      -- this will propagate options from the repl but not from eval, because
+      -- eval unsets rootOptions after compiling but before running the actual
+      -- calls to require.
+      local opts = { useMetadata = rootOptions and rootOptions.useMetadata }
       for k,v in pairs(options or {}) do opts[k] = v end
       local filename = searchModule(modulename)
       if filename then

--- a/fennel.lua
+++ b/fennel.lua
@@ -840,7 +840,7 @@ local doc = function(tgt, name)
     local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or {}, ' ')
     local docstring = (metadata:get(tgt, 'fnl/docstring') or
                            '<docstring:nil>'):gsub('\n$', ''):gsub('\n', '\n  ')
-    return string.format("(%s%s%s)\n  %s\n", name, #arglist > 0 and ' ' or '',
+    return string.format("(%s%s%s)\n  %s", name, #arglist > 0 and ' ' or '',
                          arglist, docstring)
 end
 -- Convert expressions to Lua string

--- a/fennel.lua
+++ b/fennel.lua
@@ -836,13 +836,17 @@ end
 
 local metadata = makeMetadata()
 local doc = function(tgt, name)
-    assert(tgt, name .. " not found")
-    local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or
-                                     {'#<unknown-arguments>'}, ' ')
+    if(not tgt) then return print(name .. " not found") end
     local docstring = (metadata:get(tgt, 'fnl/docstring') or
                            '#<undocumented>'):gsub('\n$', ''):gsub('\n', '\n  ')
-    return string.format("(%s%s%s)\n  %s", name, #arglist > 0 and ' ' or '',
-                         arglist, docstring)
+    if type(tgt) == "function" then
+        local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or
+                                         {'#<unknown-arguments>'}, ' ')
+        return string.format("(%s%s%s)\n  %s", name, #arglist > 0 and ' ' or '',
+                             arglist, docstring)
+    else
+        return string.format("%s\n  %s", name, docstring)
+    end
 end
 
 local function docSpecial(name, arglist, docstring)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1410,21 +1410,21 @@ SPECIALS['lua'] = function(ast, _, parent)
     end
 end
 
-SPECIALS['doc'] = function(ast, scope)
+SPECIALS['doc'] = function(ast, scope, parent)
     assert(rootOptions.useMetadata, "can't look up doc with metadata disabled.")
     assertCompile(#ast == 2, "expected one argument", ast)
-    local target = deref(assertCompile(#ast == 2 and isSym(ast[2]),
-                                       "expected one symbol", ast))
+
+    local target = deref(ast[2])
     local special = scope.specials[target]
     if special then
         return ("print([[%s]])"):format(doc(special, target))
     else
-        local mangled = combineParts(isMultiSym(ast[2]) or {target}, scope)
+        local value = tostring(compile1(ast[2], scope, parent, {nval = 1})[1])
         -- need to require here since the metadata is stored in the module
         -- and we need to make sure we look it up in the same module it was
         -- declared from.
         return ("print(require('%s').doc(%s, '%s'))")
-            :format(rootOptions.moduleName or "fennel", mangled, target)
+            :format(rootOptions.moduleName or "fennel", value, tostring(ast[2]))
     end
 end
 docSpecial('doc', {'x'},

--- a/fennel.lua
+++ b/fennel.lua
@@ -1415,11 +1415,12 @@ SPECIALS['doc'] = function(ast, scope)
     if special then
         return ("print([[%s]])"):format(doc(special, target))
     else
+        local mangled = combineParts(isMultiSym(ast[2]) or {target}, scope)
         -- need to require here since the metadata is stored in the module
         -- and we need to make sure we look it up in the same module it was
         -- declared from.
         return ("print(require('%s').doc(%s, '%s'))")
-            :format(rootOptions.moduleName or "fennel", scope.manglings[target], target)
+            :format(rootOptions.moduleName or "fennel", mangled, target)
     end
 end
 docSpecial('doc', {'x'},

--- a/fennel.lua
+++ b/fennel.lua
@@ -2825,7 +2825,7 @@ do
     -- system for that. but if you try to require the module while it's being
     -- loaded, you get a stack overflow. so we fake out the module for the
     -- purposes of boostrapping the built-in macros here.
-    local moduleName = "fennel" .. math.random(9999999)
+    local moduleName = "__fennel-bootstrap__"
     package.preload[moduleName] = function() return module end
     local env = makeCompilerEnv(nil, COMPILER_SCOPE, {})
     for name, fn in pairs(eval(stdmacros, {

--- a/fennel.lua
+++ b/fennel.lua
@@ -2713,6 +2713,8 @@ local stdmacros = [===[
  }
 ]===]
 do
+    local moduleName = "fennel" .. math.random(9999999)
+    package.preload[moduleName] = function() return module end
     local env = makeCompilerEnv(nil, COMPILER_SCOPE, {})
     for name, fn in pairs(eval(stdmacros, {
         env = env,
@@ -2722,9 +2724,12 @@ do
         -- where _G is an empty table with an __index metamethod. (openresty)
         allowedGlobals = false,
         filename = "built-ins",
+        useMetadata = true,
+        moduleName = moduleName,
     })) do
         SPECIALS[name] = macroToSpecial(fn)
     end
+    package.preload[moduleName] = nil
 end
 SPECIALS['λ'] = SPECIALS['lambda']
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -837,7 +837,8 @@ end
 local metadata = makeMetadata()
 local doc = function(tgt, name)
     assert(tgt, name .. " not found")
-    local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or {}, ' ')
+    local arglist = table.concat(metadata:get(tgt, 'fnl/arglist') or
+                                     {'#<unknown-arguments>'}, ' ')
     local docstring = (metadata:get(tgt, 'fnl/docstring') or
                            '<docstring:nil>'):gsub('\n$', ''):gsub('\n', '\n  ')
     return string.format("(%s%s%s)\n  %s", name, #arglist > 0 and ' ' or '',

--- a/fennel.lua
+++ b/fennel.lua
@@ -1369,7 +1369,7 @@ SPECIALS['fn'] = function(ast, scope, parent)
             metaFields[6] = '"' .. docstring:gsub('%s+$', '')
                 :gsub('\\', '\\\\'):gsub('\n', '\\n'):gsub('"', '\\"') .. '"'
         end
-        local metaStr = 'require("fennel").metadata'
+        local metaStr = ('require("%s").metadata'):format(rootOptions.moduleName or "fennel")
         emit(parent, string.format('%s:setall(%s, %s)', metaStr,
                                    fnName, table.concat(metaFields, ', ')))
     end
@@ -2197,7 +2197,7 @@ local function repl(options)
        local spliceSaveLocals = function(luaSource)
         -- need to require fennel here since storing metadata comes from require
         -- fennel, and we need to make sure we have the same module.
-        local replDoc = opts.useMetadata and require("fennel").doc
+        local replDoc = opts.useMetadata and require(opts.moduleName or "fennel").doc
         env.___replLocals___ = env.___replLocals___ or { doc = replDoc }
         local splicedSource = {}
         for line in luaSource:gmatch("([^\n]+)\n?") do

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -165,13 +165,14 @@
                 (: :gsub "%( " "(") (: :gsub " %)" ")"))]
     ret))
 
-(fn fennelview [root options]
+(fn fennelview [x options]
+  "Return a string representation of x."
   (let [options (or options {})
-        inspector {:appearances (count-table-appearances root {})
+        inspector {:appearances (count-table-appearances x {})
                    :depth (or options.depth 128)
                    :level 0 :buffer {} :ids {} :max-ids {}
                    :indent (or options.indent (if options.one-line "" "  "))
                    :detect-cycles? (not (= false options.detect-cycles?))}]
-    (put-value inspector root)
+    (put-value inspector x)
     (let [str (table.concat inspector.buffer)]
       (if options.one-line (one-line str) str))))

--- a/generate.fnl
+++ b/generate.fnl
@@ -42,6 +42,7 @@
 
 (set generate
      (fn [table-chance]
+       "Generate a random piece of data."
        (local table-chance (or table-chance 0.5))
        (if (> (math.random) 0.5) (generators.number)
            (> (math.random) 0.5) (generators.string)

--- a/test.lua
+++ b/test.lua
@@ -287,7 +287,7 @@ local cases = {
            (reverse-it 1 2 3 4 5 6)]]]=1,
         -- nesting quote can only happen in the compiler
         ["(eval-compiler (set tbl.nest ``nest))\
-          (tostring tbl.nest)"]="(quote, nest)",
+          (tostring tbl.nest)"]="(quote nest)",
         -- inline macros
         ["(macros {:plus (fn [x y] `(+ ,x ,y))}) (plus 9 9)"]=18,
         -- Vararg in quasiquote

--- a/test.lua
+++ b/test.lua
@@ -649,25 +649,25 @@ end
 
 print("Running tests for metadata and docstrings...")
 local docstring_tests = {
-    ['(fn foo [a] :C 1) (doc foo)'] = {'(foo a)\n  C\n',
+    ['(fn foo [a] :C 1) (doc foo)'] = {'(foo a)\n  C',
       'for named functions, (doc fnname) shows name, args invocation, docstring'},
-    ['(λ foo [] :D 1) (doc foo)'] = {'(foo)\n  D\n',
+    ['(λ foo [] :D 1) (doc foo)'] = {'(foo)\n  D',
       '(doc fnname) for named lambdas appear like named functions'},
     ['(fn ml [] "a\nmultiline\ndocstring" :result) (doc ml)'] =
-        {'(ml)\n  a\n  multiline\n  docstring\n',
+        {'(ml)\n  a\n  multiline\n  docstring',
         'multiline docstrings work correctly'},
     [ '(fn ew [] "so \\"gross\\" \\\\\\\"I\\\\\\\" can\'t even" 1) (doc ew)'] =
-        {'(ew)\n  so "gross" \\"I\\" can\'t even\n',
+        {'(ew)\n  so "gross" \\"I\\" can\'t even',
          'docstrings should be auto-escaped'},
     ['(fn foo! [-kebab- {:x x}] 1) (doc foo!)'] =
-        { "(foo! -kebab- #<table>)\n  <docstring:nil>\n",
+        { "(foo! -kebab- #<table>)\n  <docstring:nil>",
           "fn-name and args mangling" },
     ['(doc doto)'] =
         {"(doto val ...)\n  Evaluates val and splices it into the " ..
-             "first argument of subsequent forms.\n",
+             "first argument of subsequent forms.",
          "docstrings for built-in macros"},
     ['(doc doc)'] =
-        {"(doc x)\n  Print the docstring and arglist for a function, macro, or special.\n",
+        {"(doc x)\n  Print the docstring and arglist for a function, macro, or special.",
          "docstrings for special forms"},
 }
 

--- a/test.lua
+++ b/test.lua
@@ -679,7 +679,10 @@ local docstring_tests = {
          "docstrings for built-in Lua functions"},
     ['(let [x-tbl []] (fn x-tbl.y! [d] "why" 123) (doc x-tbl.y!))'] =
         {"(x-tbl.y! d)\n  why",
-         "docstrings for mangled multisyms"}
+         "docstrings for mangled multisyms"},
+    ['(let [f (fn [] "f" :f) g (fn [] f)] (doc (g)))'] =
+        {"((g))\n  f",
+         "doc on expression"},
 }
 
 local docEnv = setmetatable({ print = function(x) return x end }, { __index=_G })

--- a/test.lua
+++ b/test.lua
@@ -674,6 +674,12 @@ local docstring_tests = {
     ['(macro abc [x y z] "this is a macro." :123) (doc abc)'] =
         {"(abc x y z)\n  this is a macro.",
          "docstrings for user-defined macros"},
+    ['(doc table.concat)'] =
+        {"(table.concat #<unknown-arguments>)\n  <docstring:nil>",
+         "docstrings for built-in Lua functions"},
+    ['(let [x-tbl []] (fn x-tbl.y! [d] "why" 123) (doc x-tbl.y!))'] =
+        {"(x-tbl.y! d)\n  why",
+         "docstrings for mangled multisyms"}
 }
 
 local docEnv = setmetatable({ print = function(x) return x end }, { __index=_G })

--- a/test.lua
+++ b/test.lua
@@ -683,9 +683,13 @@ local docstring_tests = {
     ['(let [f (fn [] "f" :f) g (fn [] f)] (doc (g)))'] =
         {"((g))\n  f",
          "doc on expression"},
+    ['(local generate (fennel.dofile "generate.fnl" {:useMetadata true})) (doc generate)'] =
+        {"(generate table-chance)\n  Generate a random piece of data.",
+         "docstrings from required module."}
 }
 
-local docEnv = setmetatable({ print = function(x) return x end }, { __index=_G })
+local docEnv = setmetatable({ print = function(x) return x end, fennel = fennel},
+    { __index=_G })
 
 for code, cond_msg in pairs(docstring_tests) do
     local expected, msg = (unpack or table.unpack)(cond_msg)

--- a/test.lua
+++ b/test.lua
@@ -662,7 +662,7 @@ local docstring_tests = {
         {'(ew)\n  so "gross" \\"I\\" can\'t even',
          'docstrings should be auto-escaped'},
     ['(fn foo! [-kebab- {:x x}] 1) (doc foo!)'] =
-        { "(foo! -kebab- #<table>)\n  <docstring:nil>",
+        { "(foo! -kebab- #<table>)\n  #<undocumented>",
           "fn-name and args mangling" },
     ['(doc doto)'] =
         {"(doto val ...)\n  Evaluates val and splices it into the " ..
@@ -675,7 +675,7 @@ local docstring_tests = {
         {"(abc x y z)\n  this is a macro.",
          "docstrings for user-defined macros"},
     ['(doc table.concat)'] =
-        {"(table.concat #<unknown-arguments>)\n  <docstring:nil>",
+        {"(table.concat #<unknown-arguments>)\n  #<undocumented>",
          "docstrings for built-in Lua functions"},
     ['(let [x-tbl []] (fn x-tbl.y! [d] "why" 123) (doc x-tbl.y!))'] =
         {"(x-tbl.y! d)\n  why",
@@ -705,7 +705,7 @@ fennel.eval("(eval-compiler (set fennel._SPECIALS _SPECIALS))")
 for name in pairs(fennel._SPECIALS) do
     if((not undocumentedOk[name]) and (fennel.eval(("(doc %s )"):format(name),
                                            { useMetadata = true, env = docEnv })
-                                       :find("docstring:nil"))) then
+                                       :find("undocumented"))) then
         fail = fail + 1
         print("Missing docstring for " .. name)
     end


### PR DESCRIPTION
This addresses a bunch of the things in #179.

Making it into a macro allows it to use the "given" name rather than the name a function/special was originally defined under, which fixes one of the TODOs. I've added docstrings for `doc` and `doto` but the rest of the built-in macros and specials still need documenting.

I had to introduce a new `moduleName` option to the compiler removes the restriction that Fennel must always be required as the `"fennel"` module; we needed this anyway because sometimes you'll load the module under another path, like in Polywell: https://git.sr.ht/~technomancy/polywell/tree/master/polywell/lib

@jaawerth thoughts?