### PR TITLE
document docstrings and metadata usage

### DIFF
--- a/api.md
+++ b/api.md
@@ -185,8 +185,8 @@ fennel.eval("(doc greet)", { useMetadata = true })
 
 fennel.metadata:set(greet, "fnl/docstring", "Say hello!!!")
 fennel.doc(greet, "greet!")
--- (greet! name)
---   Say hello!!!
+--> (greet! name)
+-->   Say hello!!!
 ```
 
 ### Metadata performance note

--- a/reference.md
+++ b/reference.md
@@ -42,6 +42,33 @@ Example:
 
 The `λ` form is an alias for `lambda` and behaves identically.
 
+### Docstrings
+
+Both the `fn` and `lambda`/`λ` forms of function definition accept an optional
+docstring.
+
+```fennel
+(fn pxy [x y] "Print the sum of x and y" (print (+ x y)))
+(λ pxyz [x ?y z]
+  "Print the sum of x, y, and z. If y is not provided, defaults to 0."
+  (print (+ x (or ?y 0) z)))
+```
+
+These are ignored by default outside of the REPL, unless metadata
+is enabled from the CLI (`---metadata`) or compiler options `{useMetadata=true}`,
+in which case they are stored in a metadata table along with the arglist,
+enabling easy of function docs via the `doc` macro.
+
+```
+>> (doc pxy)
+(pxy x y)
+  Print the sum of x and y
+```
+
+All function metadata will be garbage collected along with the function itself.
+Docstrings and other metadata can also be accessed via functions on the fennel
+API (see api reference).
+
 ### Hash function literal shorthand
 
 It's pretty easy to create function literals, but Fennel provides

--- a/reference.md
+++ b/reference.md
@@ -57,7 +57,7 @@ docstring.
 These are ignored by default outside of the REPL, unless metadata
 is enabled from the CLI (`---metadata`) or compiler options `{useMetadata=true}`,
 in which case they are stored in a metadata table along with the arglist,
-enabling easy of function docs via the `doc` macro.
+enabling viewing function docs via the `doc` macro.
 
 ```
 >> (doc pxy)
@@ -66,8 +66,8 @@ enabling easy of function docs via the `doc` macro.
 ```
 
 All function metadata will be garbage collected along with the function itself.
-Docstrings and other metadata can also be accessed via functions on the fennel
-API (see api reference).
+Docstrings and other metadata can also be accessed via functions on the [fennel
+API](api.md#work-with-docstrings-and-metadata).
 
 ### Hash function literal shorthand
 

--- a/tutorial.md
+++ b/tutorial.md
@@ -15,6 +15,8 @@ closures. The [Lua reference manual][3] is a fine place to look for details.
 
 ## OK, so how do you do things?
 
+### Functions and lambdas
+
 Use `fn` to make functions. If you provide an optional name, the
 function will be bound to that name in local scope; otherwise it is
 simply a value. The argument list is provided in square brackets. The
@@ -28,6 +30,23 @@ outside.)
 (fn print-and-add [a b c]
   (print a)
   (+ b c))
+```
+
+Functions can take an optional docstring in the form of a string that
+immediately follows the arglist. Under normal compilation, this
+is removed from the emitted Lua, but in the REPL, or when compiling with
+metadata enabled (`fennel --metadata <tgt-files>`), the docstring and
+function usage can be viewed with the [`doc` macro](reference.md#docstrings):
+
+*Note: Enabling metadata is [only recommended for development purposes](api.md#metadata-performance-note).*
+
+```fennel
+(fn print-sep [sep ...]
+  "Prints args as a string, delimited by sep"
+  (print (table.concat [...] sep)))
+(doc print-sep) ; -> outputs:
+; (print-sep sep ...)
+;   Prints args as a string, delimited by sep
 ```
 
 Functions defined with `fn` are fast; they have no runtime overhead
@@ -47,6 +66,10 @@ Note that the second argument `?y` is allowed to be `nil`, but `z` is not:
 ```fennel
 (print-calculation 5 nil 3) ; -> 2
 ```
+
+Like `fn`, lambdas accept an optional docstring after the arglist.
+
+### Locals and variables
 
 Locals are introduced using `let` with the names and values wrapped in
 a single set of square brackets:


### PR DESCRIPTION
Per an item #179, did an initial pass on documenting docstrings and metadata in the api, reference, and tutorial sections.