### PR TITLE
Marked things that changed in v0.3, in the documentation

### DIFF
--- a/api.md
+++ b/api.md
@@ -10,7 +10,7 @@ usually accept these fields:
 * `correlate`: when this is truthy, Fennel attempts to emit Lua where the line
   numbers match up with the Fennel input code; useful for situation where code
   that isn't under your control will print the stack traces.
-* `useMetadata`: enables or disables [metadata](#work-with-docstrings-and-metadata),
+* `useMetadata` *(since 0.3.0)*: enables or disables [metadata](#work-with-docstrings-and-metadata),
   allowing use of the doc macro. Intended for development purposes
   (see [performance note](#metadata-performance-note)); defaults to
   true for REPL only.
@@ -155,6 +155,8 @@ end
 ```
 
 ## Work with docstrings and metadata
+
+*(Since 0.3.0)*
 
 When running a REPL or using compile/eval with metadata enabled, each function
 declared with `fn` or `λ/lambda` will use the created function as a key on

--- a/reference.md
+++ b/reference.md
@@ -44,6 +44,8 @@ The `λ` form is an alias for `lambda` and behaves identically.
 
 ### Docstrings
 
+*(Since 0.3.0)*
+
 Both the `fn` and `lambda`/`λ` forms of function definition accept an optional
 docstring.
 
@@ -70,6 +72,8 @@ Docstrings and other metadata can also be accessed via functions on the fennel
 API with `fennel.metadata`.
 
 ### Hash function literal shorthand
+
+*(Since 0.3.0)*
 
 It's pretty easy to create function literals, but Fennel provides
 an even shorter form of functions. Hash functions are anonymous
@@ -476,6 +480,8 @@ Example:
 
 ### `length` string or table length
 
+*(Changed in 0.3.0: the function was called `#` before.)*
+
 Returns the length of a string or table. Note that the length of a
 table with gaps in it is undefined; it can return a number
 corresponding to any of the table's "boundary" positions between nil
@@ -519,7 +525,7 @@ Looks up a function in a table and calls it with the table as its
 first argument. This is a common idiom in many Lua APIs, including
 some built-in ones.
 
-Just like Lua, you can perform a method call by calling a function
+*(Since 0.3.0)* Just like Lua, you can perform a method call by calling a function
 name where `:` separates the table variable and method name.
 
 Example:
@@ -669,7 +675,8 @@ instance, here is a macro function which implements `when2` in terms of
 A full explanation of how macros work is out of scope for this document,
 but you can think of it as a compile-time template function. The backtick
 on the third line creates a template for the code emitted by the macro. The
-`,` serves as "unquote" which splices values into the template.
+`,` serves as "unquote" which splices values into the template. *(Changed
+in 0.3.0: `@` was used instead of `,` before.)*
 
 Assuming the code above is in the file "my-macros.fnl" then it turns this input:
 
@@ -698,6 +705,8 @@ Note that the macro interface is still preliminary and is subject to
 change over time.
 
 ### `macros`
+
+*(Since 0.3.0)*
 
 Defines a table of macros local to the current fennel file. Note that
 inside the macro definitions, you cannot access variables and bindings
@@ -731,7 +740,7 @@ they are passed a form which has side-effects, the result will be unexpected:
 (print (my-max (f) 2)) ; -> 3 since (f) is called twice in the macro body above
 ```
 
-In order to prevent accidental symbol capture[2], you may not bind a
+*(Since 0.3.0)* In order to prevent accidental symbol capture[2], you may not bind a
 bare symbol inside a backtick as an identifier. Appending a `#` on
 the end of the identifier name as above invokes "auto gensym" which
 guarantees the local name is unique.


### PR DESCRIPTION
Rationale: since only the latest version of the docs is available at fennel-lang.org (currently), some people may visit it who are still using a previous version. It would be helpful toward them to note changes between versions right in the docs, so there's no need to bump into incompatibilities and then study the changelog. IMO this and/or docs versioning will need to be introduced sooner or later.

Of course, I don't know if the APIs change too often yet and it's too early for versioning, but that doesn't seem to be the case so far.

Not sure that I caught all changes in 0.3.

Didn't touch the tutorial since I suppose people use it with the latest Fennel version.