### PR TITLE
readline completion on table fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.4.0 / ???
 
+* allow REPL readline completion to descend into table fields when using dot
+accessor in identifier (#192)
 * ???
 
 ## 0.3.0 / 2019-09-22

--- a/fennel
+++ b/fennel
@@ -124,7 +124,13 @@ local function tryReadline(opts)
           completer = replCompleter
         end
         local function replCompleter(text, from, to)
-          if completer then return completer(text:sub(from, to)) else return {} end
+          if completer then
+            -- stop completed syms from adding extra space on match
+            readline.set_completion_append_character('')
+            return completer(text:sub(from, to))
+          else
+            return {}
+          end
         end
         readline.set_complete_function(replCompleter)
       end

--- a/fennel.lua
+++ b/fennel.lua
@@ -2325,21 +2325,35 @@ local function repl(options)
 
     local replCompleter = function(text)
         local matches = {}
-        local inputFragment = text:gsub("[%s)(]*(.+)", "%1")
+        local inputFragment = text:gsub(".*[%s)(]+", "")
 
-        -- adds any matching keys from the provided generator/iterator to matches
-        local function addMatchesFromGen(next, param, state)
-          for k in next, param, state do
+        -- adds partial key matches in tbl to the match list
+        local function addPartials(input, tbl, prefix)
+          for k in pairs(tbl) do
             if #matches >= 40 then break -- cap completions at 40 to avoid overwhelming
-            elseif inputFragment == k:sub(0, #inputFragment) then
-                table.insert(matches, k)
+            elseif input == k:sub(0, #input) then
+              table.insert(matches, prefix .. k)
             end
           end
         end
-        addMatchesFromGen(pairs(env._ENV or env._G or {}))
-        addMatchesFromGen(pairs(env.___replLocals___ or {}))
-        addMatchesFromGen(pairs(SPECIALS or {}))
-        addMatchesFromGen(pairs(scope.specials or {}))
+        -- adds matches to the match list traversing
+        local function addMatches(input, tbl, prefix)
+          prefix = prefix and prefix .. "." or ""
+          -- check for table access field.child, and if field is a table, recur
+          if string.find(input, "%.") then
+            local head, tail = string.match(input, "^([^.]+)%.(.*)")
+            if type(tbl[head]) == "table" then
+              return addMatches(tail, tbl[head], prefix .. head)
+            end
+          else
+            addPartials(input, tbl, prefix)
+          end
+        end
+
+        addMatches(inputFragment, env._ENV or env._G or {})
+        addMatches(inputFragment, env.___replLocals___ or {})
+        addMatches(inputFragment, SPECIALS or {})
+        addMatches(inputFragment, scope.specials or {})
         return matches
     end
     if opts.registerCompleter then opts.registerCompleter(replCompleter) end

--- a/fennel.lua
+++ b/fennel.lua
@@ -2336,7 +2336,7 @@ local function repl(options)
             end
           end
         end
-        -- adds matches to the match list traversing
+        -- adds matches to the match list, descending into table fields
         local function addMatches(input, tbl, prefix)
           prefix = prefix and prefix .. "." or ""
           if not string.find(input, "%.") then -- no (more) dots, so add matches

--- a/fennel.lua
+++ b/fennel.lua
@@ -2339,14 +2339,13 @@ local function repl(options)
         -- adds matches to the match list traversing
         local function addMatches(input, tbl, prefix)
           prefix = prefix and prefix .. "." or ""
+          if not string.find(input, "%.") then -- no (more) dots, so add matches
+            return addPartials(input, tbl, prefix)
+          end
+          local head, tail = string.match(input, "^([^.]+)%.(.*)")
           -- check for table access field.child, and if field is a table, recur
-          if string.find(input, "%.") then
-            local head, tail = string.match(input, "^([^.]+)%.(.*)")
-            if type(tbl[head]) == "table" then
-              return addMatches(tail, tbl[head], prefix .. head)
-            end
-          else
-            addPartials(input, tbl, prefix)
+          if type(tbl[head]) == "table" then
+            return addMatches(tail, tbl[head], prefix .. head)
           end
         end
 


### PR DESCRIPTION
Resolves #188 

## Details
If your current partial identifier contains `.`, it will recursively consume the leading text and see if it's a table, then start matching on children.

To make it easier to complete table paths, I got rid of the appended space upon successful completion (which was a default in [readline.lua](https://pjb.com.au/comp/lua/readline.html) that has to be overridden each time with `set_completion_append_character`).

I also simplified the way it's tokenizing the input (line 2328 in the diff) to obtain the inputFragment it will try to complete.

## Why no tests?

I was initially going to add some tests, but I realized we don't have any readline-related tests at all, so I think it makes more sense to add this along with any/all other tests we create as part of #187 