### PR TITLE
Fix completion for mangled syms & tables w/ complex keys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 * allow REPL readline completion to descend into table fields when using dot
 accessor in identifier (#192)
-* ???
+* correct REPL completer to correctly handle symbol mangling (#195)
 
 ## 0.3.0 / 2019-09-22
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -2356,8 +2356,8 @@ local function repl(options)
 
         addMatches(inputFragment, scope.specials or {})
         addMatches(inputFragment, SPECIALS or {})
-        addMatches(inputFragment, env.___replLocals___ or {}, nil)
-        addMatches(inputFragment, env, nil)
+        addMatches(inputFragment, env.___replLocals___ or {})
+        addMatches(inputFragment, env)
         addMatches(inputFragment, env._ENV or env._G or {})
         return matches
     end

--- a/fennel.lua
+++ b/fennel.lua
@@ -2334,7 +2334,7 @@ local function repl(options)
                     k = scope.unmanglings[k] or k
                 end
                 if #matches >= 40 then break -- cap completions at 40
-                elseif input == k:sub(0, #input) then
+                elseif type(k) == 'string' and input == k:sub(0, #input) then
                     table.insert(matches, prefix .. k)
                 end
             end

--- a/fennel.lua
+++ b/fennel.lua
@@ -2328,31 +2328,34 @@ local function repl(options)
         local inputFragment = text:gsub(".*[%s)(]+", "")
 
         -- adds partial key matches in tbl to the match list
-        local function addPartials(input, tbl, prefix)
-          for k in pairs(tbl) do
-            if #matches >= 40 then break -- cap completions at 40 to avoid overwhelming
-            elseif input == k:sub(0, #input) then
-              table.insert(matches, prefix .. k)
+        local function addPartials(input, tbl, prefix, unmangle)
+            for k in pairs(tbl) do
+                local rawKey = unmangle and unmangle[k] or k
+                if #matches >= 40 then break -- cap completions at 40
+                elseif input == rawKey:sub(0, #input) then
+                    table.insert(matches, prefix .. rawKey)
+                end
             end
-          end
         end
         -- adds matches to the match list, descending into table fields
-        local function addMatches(input, tbl, prefix)
-          prefix = prefix and prefix .. "." or ""
-          if not string.find(input, "%.") then -- no (more) dots, so add matches
-            return addPartials(input, tbl, prefix)
-          end
-          local head, tail = string.match(input, "^([^.]+)%.(.*)")
-          -- check for table access field.child, and if field is a table, recur
-          if type(tbl[head]) == "table" then
-            return addMatches(tail, tbl[head], prefix .. head)
-          end
+        local function addMatches(input, tbl, prefix, unmangle)
+            prefix = prefix and prefix .. "." or ""
+            if not string.find(input, "%.") then -- no (more) dots, so add matches
+                return addPartials(input, tbl, prefix, unmangle)
+            end
+            -- check for table access field.child, and if field is a table, recur
+            local head, tail = string.match(input, "^([^.]+)%.(.*)")
+            local rawHead = unmangle and unmangle[head] or head -- check mangling
+            if type(tbl[rawHead]) == "table" then
+                return addMatches(tail, tbl[rawHead], prefix .. rawHead)
+            end
         end
 
-        addMatches(inputFragment, env._ENV or env._G or {})
-        addMatches(inputFragment, env.___replLocals___ or {})
-        addMatches(inputFragment, SPECIALS or {})
         addMatches(inputFragment, scope.specials or {})
+        addMatches(inputFragment, SPECIALS or {})
+        addMatches(inputFragment, env.___replLocals___ or {}, nil, scope.unmanglings)
+        addMatches(inputFragment, env, nil, scope.unmanglings)
+        addMatches(inputFragment, env._ENV or env._G or {})
         return matches
     end
     if opts.registerCompleter then opts.registerCompleter(replCompleter) end

--- a/test.lua
+++ b/test.lua
@@ -781,6 +781,59 @@ do
     end
 end
 
+---- REPL tests ----
+print("Running tests for REPL completion...")
+local wrapRepl = function()
+    local replComplete
+    local replSend = coroutine.wrap(function()
+        local output = {}
+        fennel.repl({
+            readChunk = function()
+                local chunk = coroutine.yield(output)
+                output = {}
+                return chunk and chunk .. '\n' or nil
+            end,
+            onValues = function(xs)
+                table.insert(output, xs)
+            end,
+            registerCompleter = function(completer)
+                replComplete = completer
+            end,
+            pp = function(x) return x end,
+        })
+    end) replSend()
+    return replSend, replComplete
+end
+
+-- Skip REPL tests in non-JIT Lua 5.1 only to avoid engine coroutine bug
+if _VERSION ~= 'Lua 5.1' or type(jit) == 'table' then
+    local send, comp = wrapRepl()
+    send('(local [foo foo-bar* moe-larry] [1 2 {:*curly* "Why soitenly!"}])')
+    send('(local [!x-y !x_y] [1 2])')
+    local testCases = {
+        {comp'foo',  {'foo', 'foo-bar*'},
+            'local completion works & accounts for mangling'},
+        {comp'moe-larry.', { 'moe-larry.*curly*' },
+            'completion traverses tables without mangling keys when input is "tbl-var."'},
+        {send'(values !x-y !x_y)', {{1, 2}},
+            'mangled locals do not collide'},
+        {comp'!x', {'!x-y', '!x_y'},
+            'completions on mangled locals do not collide'},
+    }
+    for _, results in ipairs(testCases) do
+        local a, b, msg = (unpack or table.unpack)(results)
+        if deep_equal(a, b) then
+            pass = pass + 1
+        else
+            fail = fail + 1
+            print(string.format('Expected: %s to be %s:\n\t%s', a, b, msg))
+        end
+    end
+    send()
+else
+    print('Skipping REPL tests in (non-LuaJIT) Lua 5.1')
+end
+
 
 print(string.format("\n%s passes, %s failures, %s errors.", pass, fail, err))
 if(fail > 0 or err > 0) then os.exit(1) end


### PR DESCRIPTION
- Fixes #195 
- Also fixes an additional bug I realized I introduced with deep table completion, where non-string keys on a table throw an error due to `k:sub(...)`.

I created a wrapper for the REPL so we could write tests against both the REPL itself and the completer. Right now it's just in `tests.lua`, but I think we should start to consider pulling some of those helpers out into a `test-utils.lua` module. Figured I'd submit this and we could look at doing that in another PR, though.