### PR TITLE
Fix windows batch path

### DIFF
--- a/fennel.bat
+++ b/fennel.bat
@@ -1,2 +1,2 @@
 @echo off
-lua fennel %*
+lua %~dp0fennel %*


### PR DESCRIPTION
**Issue:**
When using Windows and adding the git repo to the Path, an error occurs because windows cannot find `fennel`.

**Fix:**
To fix this, I used `%~dp0` before `fennel`. This means that the drive letter and script path is added before `fennel`, forcing it to be the complete path.