### PR TITLE
Fix bug where if with implicit nil else wasn't binding target local.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1636,6 +1636,9 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
             if hasElse then
                 emit(lastBuffer, 'else', ast)
                 emit(lastBuffer, elseBranch.chunk, ast)
+            elseif(innerTarget) then
+                emit(lastBuffer, 'else', ast)
+                emit(lastBuffer, ("%s = nil"):format(innerTarget), ast)
             end
             emit(lastBuffer, 'end', ast)
         elseif not branches[i + 1].nested then

--- a/test.lua
+++ b/test.lua
@@ -123,6 +123,7 @@ local cases = {
         -- make sure bad code isn't emitted when an always-true
         -- condition exists in the middle of an if
         ["(if false :y true :x :trailing :condition)"]="x",
+        ["(let [b :original b (if false :not-this)] (or b :nil))"]="nil",
     },
 
     core = {


### PR DESCRIPTION
An `if` that's having its value bound to a local must set that local no
matter what. Previously the local would never be set if the conditions
all were falsey and the else clause was an implicit nil; now we check
that case and set it as well.

Fixes #191.

@bakpakin I could use some review here; I'm not sure that I'm using `innerTarget` correctly. There could be some subtlety about it that I'm overlooking.