### PR TITLE
Add optional unused local checking with --check-unused-locals flag.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,9 @@
 
 ## 0.4.0 / ???
 
-* allow REPL readline completion to descend into table fields when using dot
-accessor in identifier (#192)
-* correct REPL completer to correctly handle symbol mangling (#195)
+* Optionally check for unused locals with `--check-unused-locals`
+* Make repl completion descend into nested table fields (#192)
+* Fix repl completer to correctly handle symbol mangling (#195)
 
 ## 0.3.0 / 2019-09-22
 
@@ -23,7 +23,7 @@ identifiers in backtick.
 * Add `include` special form to selectively inline modules in compiled output
 * Add `--require-as-include` to inline required modules in compiled output
 * Add `--eval` argument to command-line launcher
-* Add environment variable `FENNEL_PATH` to `path`.
+* Add environment variable `FENNEL_PATH` to `path`
 * Fix a few bugs in `match`
 * **Remove** undocumented support for single-quoted strings
 * Add support for guard clauses with `?` in pattern matching
@@ -55,7 +55,7 @@ The second minor release introduces backtick, making macro authoring
 much more streamlined. Macros may now be defined in the same file, and
 pattern matching is added.
 
-* Prevent creation of bindings that collide with special forms and macros.
+* Prevent creation of bindings that collide with special forms and macros
 * Make parens around steps optional in arrow macros for single-arg calls
 * Allow macros to be defined inline with `macros`
 * Add `--add-package-path` and `--add-fennel-path` to launcher script

--- a/fennel
+++ b/fennel
@@ -19,6 +19,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --add-fennel-path  PATH : Add PATH to fennel.path for finding Fennel modules
   --globals G1[,G2...]    : Allow these globals in addition to standard ones
   --globals-only G1[,G2]  : Same as above, but exclude standard ones
+  --check-unused-locals   : Raise error when compiling code with unused locals
   --require-as-include    : Inline required modules in the output
   --metadata              : Enable function metadata, even in compiled output
   --no-metadata           : Disable function metadata, even in REPL
@@ -75,6 +76,9 @@ for i=#arg, 1, -1 do
         table.remove(arg, i)
     elseif arg[i] == "--correlate" then
         options.correlate = true
+        table.remove(arg, i)
+    elseif arg[i] == "--check-unused-locals" then
+        options.checkUnusedLocals = true
         table.remove(arg, i)
     elseif arg[i] == "--globals" then
         allowGlobals(table.remove(arg, i+1))

--- a/fennel.lua
+++ b/fennel.lua
@@ -1244,6 +1244,15 @@ local function compileDo(ast, scope, parent, start)
     end
 end
 
+-- Raises compile error if unused locals are found and we're checking for them.
+local function checkUnused(scope, ast)
+    if not rootOptions.checkUnusedLocals then return end
+    for symName in pairs(scope.symmeta) do
+        assertCompile(scope.symmeta[symName].used or symName:find("^_"),
+                      ("unused local %s"):format(symName), ast)
+    end
+end
+
 -- Implements a do statement, starting at the 'start' element. By default, start is 2.
 local function doImpl(ast, scope, parent, opts, start, chunk, subScope)
     start = start or 2
@@ -1303,6 +1312,7 @@ local function doImpl(ast, scope, parent, opts, start, chunk, subScope)
     end
     emit(parent, chunk, ast)
     emit(parent, 'end', ast)
+    checkUnused(subScope, ast)
     return retexprs
 end
 
@@ -1398,6 +1408,7 @@ SPECIALS['fn'] = function(ast, scope, parent)
                                    fnName, table.concat(metaFields, ', ')))
     end
 
+    checkUnused(fScope, ast)
     return expr(fnName, 'sym')
 end
 docSpecial('fn', {'name?', 'args', 'docstring?', '...'},

--- a/test.lua
+++ b/test.lua
@@ -543,6 +543,10 @@ local compile_failures = {
     ["(let [t []] (set t::x :y))"]="malformed multisym: t.:x",
     ["(local a~b 3)"]="illegal character: ~",
     ["(print @)"]="illegal character: @",
+    -- unused locals checking
+    ["(let [x 1 y 2] y)"]="unused local x",
+    ["(fn [xx y] y)"]="unused local xx",
+    ["(fn [_x y z] y)"]="unused local z",
     -- unmangled globals shouldn't conflict with mangled locals
     ["(local a-b 1) (global a_b 2)"]="global a_b conflicts with local",
     ["(local a-b 1) (global [a_b] [2])"]="global a_b conflicts with local",
@@ -561,7 +565,8 @@ local compile_failures = {
 
 print("Running tests for compile errors...")
 for code, expected_msg in pairs(compile_failures) do
-    local ok, msg = pcall(fennel.compileString, code, {allowedGlobals = {"pairs"}})
+    local ok, msg = pcall(fennel.compileString, code,
+                          {allowedGlobals = {"pairs"}, checkUnusedLocals = true})
     if(ok) then
         fail = fail + 1
         print(" Expected failure when compiling " .. code .. ": " .. msg)


### PR DESCRIPTION
This ended up being quite simple since the `hashfn` implementation already added `.used` to symbol metadata.