### PR TITLE
Don't double-emit `else` when checking innerTarget

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1664,7 +1664,8 @@ SPECIALS['if'] = function(ast, scope, parent, opts)
             if hasElse then
                 emit(lastBuffer, 'else', ast)
                 emit(lastBuffer, elseBranch.chunk, ast)
-            elseif(innerTarget) then
+            -- TODO: Consolidate use of condLine ~= "else" with hasElse
+            elseif(innerTarget and condLine ~= 'else') then
                 emit(lastBuffer, 'else', ast)
                 emit(lastBuffer, ("%s = nil"):format(innerTarget), ast)
             end

--- a/test.lua
+++ b/test.lua
@@ -124,6 +124,9 @@ local cases = {
         -- condition exists in the middle of an if
         ["(if false :y true :x :trailing :condition)"]="x",
         ["(let [b :original b (if false :not-this)] (or b :nil))"]="nil",
+        -- make sure nested/assigned conditionals always set the tgt,
+        -- and don't double-emit "else"
+        ["(let [x 3 res (if (= x 1) :ONE (= x 2) :TWO true :???)] res)"] = "???",
         -- Conditional of while
         ["(while (let [f false] f) (lua :break))"]=nil,
         ["(var i 0) (var s 0) (while (let [l 11] (< i l)) (set s (+ s i)) (set i (+ 1 i))) s"]=55
@@ -370,6 +373,7 @@ local cases = {
         ["(match (io.open \"/does/not/exist\") (nil msg) :err f f)"]="err",
         -- last clause becomes default
         ["(match [1 2 3] [3 2 1] :no [2 9 1] :NO :default)"]="default",
+        ["(let [x 3 res (match x 1 :ONE 2 :TWO _ :???)] res)"]="???",
         -- intra-pattern unification
         ["(match [1 2 3] [x y x] :no [x y z] :yes)"]="yes",
         ["(match [1 2 1] [x y x] :yes)"]="yes",


### PR DESCRIPTION
Fixes #211

This is a bit of a quick fix - it looks like the logic for `if` should, longterm, be consolidated into using `hasElse` for everything, which will make this more maintainable. For now, though, this should be enough to cut a `0.3.1-1` or `0.3.2`.

If we want to fix the bug before 0.4.0, we'll likely need to cut a separate bugfix release by also merging this onto `0.3.1`, before the addition of kvmap.