### PR TITLE
re-implement include to use package.preload

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -2818,11 +2818,13 @@ Macro module should return a table of macro functions with string keys."
          scope           (get-scope)
          compile         (if fennel? fennel.compileString #$)
          code            (if (and mod-path (not (. scope.includes module-name)))
-                         (: (io.open mod-path) :read :*a))
+                             (: (io.open mod-path) :read :*a))
          lua-code        (if code (compile code))
          found           (or (. scope.includes module-name) lua-code)
-         includer        `(tset package.preload ,module-name
-                                ((or loadstring load) ,lua-code))]
+         includer        `(when (and (not (. package.preload ,module-name))
+                                     (= nil (. package.loaded ,module-name)))
+                                (tset package.preload ,module-name
+                                      ((or loadstring load) ,lua-code)))]
      ; if requireAsInclude is enabled when unresolvable, fallback to require
      (assert (or found (get-option (get-scope) :requireAsInclude))
              (.. "could not find module " module-name))


### PR DESCRIPTION
Fixes #214 

This re-implements the `include` special as a macro that utilizes `package.preload` and `require`. It could use a heavier than normal review since it changes the underlying functionality of how it works so `include` and `--require-as-include` will work like require for a user.

@bakpakin, you may want to review this one since you implemented the original `include` and this makes quite a few changes to how it works.

## Notes
- Will use `load`/`loadstring` on a string literal instead of inlining the module as a closure. This could be changed back to a function wrapper, but this way it won't get upvalues from the parent scope.
- Got rid of `opts.fallback` and instead uses require with a simple `(values require)` to emit require and avoid infinite recursion when `options.requireAsInclude` is enabled.
- Adds a `get-option` function to the compiler/macro env, allowing macros to inspect options. I also considered a `get-options` instead that returns a shallow copy of the entire options table - could have gone either way here, and input is welcome.

## Caveats
While this will work in nested context, and will also ensure referential equality is correct. There are still a couple of edge cases though:
- When requiring modules that in turn require modules that have already been `include`ed by this macro, it will grab the one that's already been loaded. Similarly, this checks `package.loaded` and `package.preload` to avoid attempting to include something already loaded by Lua. However, it will still result in larger bundles due to the embedded (but unused) module text.
- The compiler output runs but it's a bit ugly due to the way it handles line-breaks.
- Not sure of the `(or loadstring load)` is necessary? I saw it falling back to load in `loadCode` in the compiler, so duplicated that here, but it looks like Lua 5.1-5.3 and LuaJit all have `loadstring` so this could potentially be removed.
- No tests. There aren't any tests yet for the `include` macro, and I didn't add any here yet. We may want to consider doing so?