### PR TITLE
make `include` special use package.preload

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -819,7 +819,7 @@ do
             print(" Expected include to have result: " .. expected)
         elseif out.quux ~= false then
             fail = fail + 1
-            print(" Expected include not to leak globals into Lua locals")
+            print(" Expected include not to leak upvalues into included modules")
         else
             pass = pass + 1
         end


### PR DESCRIPTION
Fixes #214
Alternative to #215 that:
- Leaves `include` as a special, for now (may revisit after we implement macro expansion as a compiler phase)
- Inlines the module code on the top of the entrypoint, wrapped in a function, ensuring no leakage of locals from the parent context into the wrapped code, and that execution order is maintained
- Sets the wrapped function on `package.preload` so that `require` can be used normally
- Emits `require` in place of `include`

## setting package.preload
Setting package.preload ensures execution order is maintained, and that duplicate and nested requires will have referential equality even if there's more than one entrypoint. What actually gets emitted is the equivalent of:
```lua
package.preload[modulename] = package.preload[modulename] or wrapped_function
```
This ensures that `include` maintains the same expectations as require, allowing one to override or mock the target module by setting it on `package.preload[modulename]`.