### PR TITLE
fix outerTarget shadowing in let/do bindings

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -231,6 +231,9 @@ local cases = {
         ["(let [{:a [x y z]} {:a [1 2 4]}] (+ x y z))"]=7,
         -- Local shadowing in let form
         ["(let [x 1 x (if (= x 1) 2 3)] x)"]=2,
+        -- do/let shadowing
+        ["(let [x (let [x 1] (* x 2))] x)"]=2,
+        ["(var x 1) (set x (do (local x (* x 2)) x)) x"]=2,
     },
 
     loops = {


### PR DESCRIPTION
Partially addresses #218 
Added some code that checks for `outerTarget` in `subScope` and, if present, generates an intermediate target to assign to.

I initially did this in a separate conditional branch, but realized I could reuse the existing code that generates bindings when `opts.nval ~= 0`. It seems cleaner, but I left the commit in place just in case anyone wants to disagree.