### PR TITLE
Support printing lists and syms using fennelview

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -58,14 +58,14 @@ end
 
 local function deref(self) return self[1] end
 
-local SYMBOL_MT = { 'SYMBOL', __tostring = deref }
+local function listToString(self, tostring2)
+    return '(' .. table.concat(map(self, tostring2 or tostring), ' ', 1, #self) .. ')'
+end
+
+local SYMBOL_MT = { 'SYMBOL', __tostring = deref, __fennelview = deref }
 local EXPR_MT = { 'EXPR', __tostring = deref }
 local VARARG = setmetatable({ '...' }, { 'VARARG', __tostring = deref })
-local LIST_MT = { 'LIST',
-    __tostring = function (self)
-        return '(' .. table.concat(map(self, tostring), ' ', 1, #self) .. ')'
-    end
-}
+local LIST_MT = { 'LIST', __tostring = listToString, __fennelview = listToString }
 local SEQUENCE_MT = { 'SEQUENCE' }
 
 -- Load code with an environment in all recent Lua versions

--- a/fennelview.fnl
+++ b/fennelview.fnl
@@ -176,7 +176,7 @@
                    :level 0 :buffer {} :ids {} :max-ids {}
                    :indent (or options.indent (if options.one-line "" "  "))
                    :detect-cycles? (not (= false options.detect-cycles?))
-                   :fennelview fennelview}]
+                   :fennelview #(fennelview $1 options)}]
     (put-value inspector x)
     (let [str (table.concat inspector.buffer)]
       (if options.one-line (one-line str) str))))

--- a/test.lua
+++ b/test.lua
@@ -420,6 +420,9 @@ local cases = {
         ["((require :fennelview) (let [t {}] [t t]))"]="[ {} #<table 2> ]",
         ["((require :fennelview) (let [t {}] [t t]) {:detect-cycles? false})"]=
             "[ {} {} ]",
+        -- ensure fennelview works on lists and syms
+        ["(eval-compiler (set _G.out ((require :fennelview) '(a {} [1 2])))) _G.out"]=
+            "(a {} [ 1 2 ])",
     },
 }
 


### PR DESCRIPTION
Previously:

```
[ {
    :byteend 28
    :bytestart 17
    :closer 41
    :line 1
    1 {
       :byteend 19
       :bytestart 18
       :line 1
       1 "fn"
       }
    2 [ {
         :byteend 22
         :bytestart 22
         :line 1
         1 "a"
         } {
            :byteend 24
            :bytestart 24
            :line 1
            1 "b"
            } ]
    3 0
    } {
       :byteend 15
       :bytestart 15
       :line 1
       1 "f"
       } ]
```

Now:

```
(fn [a b] 0)
```

This is done by extending fennelview to support a `__fennelview` metamethod for a given table which is called with the object in question as well as the `fennelview` function itself, so that we can use it on lists which may contain non-list tables that need to be serialized.

The `LIST_MT` and `SYMBOL_MT` metatables are both set to use their existing `tostring` implementations for this, with the caveat that they now take `fennelview` as a second arg for recursive purposes.