### PR TITLE
Use pcall when setting metadata.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1473,8 +1473,8 @@ SPECIALS["fn"] = function(ast, scope, parent)
                              :gsub('"', '\\"') .. '"')
         end
         local metaStr = ('require("%s").metadata'):format(rootOptions.moduleName or "fennel")
-        emit(parent, string.format('%s:setall(%s, %s)', metaStr,
-                                   fnName, table.concat(metaFields, ', ')))
+        emit(parent, string.format('pcall(function() %s:setall(%s, %s) end)',
+                                   metaStr, fnName, table.concat(metaFields, ', ')))
     end
 
     checkUnused(fScope, ast)


### PR DESCRIPTION
This allows problems like https://gitlab.com/alexjgriffith/min-love2d-fennel/issues/2 to be
avoided; it should only throw when looking up metadata, not when setting it. (when you have the Fennel module in a location other than the root fennel.lua)

If we end up doing #220 then this won't be necessary, but until we decide what to do with that, this should make the problem a little less impactful.