### PR TITLE
Optimize top level forms in eval that are not the last in a file.

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -2156,6 +2156,7 @@ local function compileStream(strm, options)
     for i = 1, #vals do
         local exprs = compile1(vals[i], scope, chunk, {
             tail = i == #vals,
+            nval = i < #vals and 0 or nil
         })
         keepSideEffects(exprs, chunk, nil, vals[i])
     end


### PR DESCRIPTION
Address issue #239. Should be fairly simple but hopefully I won't break anything, and should in general shrink Lua output.