### PR TITLE
ensure that (values) emits valid lua 241 fix

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -964,9 +964,9 @@ local function handleCompileOpts(exprs, parent, opts, ast)
         emit(parent, ('return %s'):format(exprs1(exprs)), ast)
     end
     if opts.target then
-        local expr = exprs1(exprs)
-        if expr == '' then expr = 'nil' end
-        emit(parent, ('%s = %s'):format(opts.target, expr), ast)
+        local result = exprs1(exprs)
+        if result == '' then result = 'nil' end
+        emit(parent, ('%s = %s'):format(opts.target, result), ast)
     end
     if opts.tail or opts.target then
         -- Prevent statements and expression from being used twice if they

--- a/fennel.lua
+++ b/fennel.lua
@@ -964,7 +964,9 @@ local function handleCompileOpts(exprs, parent, opts, ast)
         emit(parent, ('return %s'):format(exprs1(exprs)), ast)
     end
     if opts.target then
-        emit(parent, ('%s = %s'):format(opts.target, exprs1(exprs)), ast)
+        local expr = exprs1(exprs)
+        if expr == '' then expr = 'nil' end
+        emit(parent, ('%s = %s'):format(opts.target, expr), ast)
     end
     if opts.tail or opts.target then
         -- Prevent statements and expression from being used twice if they
@@ -1232,7 +1234,9 @@ local function destructure(to, from, ast, scope, parent, opts)
         elseif isTable(left) then -- table destructuring
             if top then rightexprs = compile1(from, scope, parent) end
             local s = gensym(scope)
-            emit(parent, ("local %s = %s"):format(s, exprs1(rightexprs)), left)
+            local right = exprs1(rightexprs)
+            if right == '' then right = 'nil' end
+            emit(parent, ("local %s = %s"):format(s, right), left)
             for k, v in pairs(left) do
                 if isSym(left[k]) and left[k][1] == "&" then
                     assertCompile(type(k) == "number" and not left[k+2],

--- a/test/misc.lua
+++ b/test/misc.lua
@@ -99,7 +99,7 @@ local function test_empty_values()
               {: h} {:h (values)}]
               (not (or a b c d e f g h)))
     ]=], "empty (values) should resolve to nil")
-    
+
     local broken_code = fennel.compile [[
         (local [x] (values))
         (local {: y} (values))

--- a/test/misc.lua
+++ b/test/misc.lua
@@ -88,11 +88,32 @@ local function test_env_iteration()
                    "Expected mangled globals to be kept across eval invocations.")
 end
 
+local function test_empty_values()
+    l.assertTrue(fennel.eval[=[
+        (let [a (values)
+              b (values (values))
+              (c d) (values)
+              e (if (values) (values))
+              f (while (values) (values))
+              [g] [(values)]
+              {: h} {:h (values)}]
+              (not (or a b c d e f g h)))
+    ]=], "empty (values) should resolve to nil")
+    
+    local broken_code = fennel.compile [[
+        (local [x] (values))
+        (local {: y} (values))
+    ]]
+    l.assertNotNil(broken_code, "code should compile")
+    l.assertError(broken_code, "code should fail at runtime");
+end
+
 return {
     test_leak=test_leak,
     test_runtime_quote=test_runtime_quote,
     test_global_mangling=test_global_mangling,
     test_include=test_include,
     test_env_iteration=test_env_iteration,
+    test_empty_values=test_empty_values,
 }
 


### PR DESCRIPTION
Should fix #241. I can't imagine this causing any other bugs. I've added a test specifically for empty values.