### PR TITLE
readline enhancements in REPL

### DIFF
--- a/fennel
+++ b/fennel
@@ -122,10 +122,8 @@ local function tryReadline(opts)
         if readline.set_readline_name then -- added as of readline.lua 2.6-0
             readline.set_readline_name('fennel')
         end
-
         readline.set_options({
-            keeplines = 1000
-        })
+            keeplines = 1000, histfile = '', })
         function opts.readChunk(parserState)
             local prompt = parserState.stackSize > 0 and '.. ' or '>> '
             local str = readline.readline(prompt)
@@ -149,6 +147,7 @@ local function tryReadline(opts)
           end
         end
         readline.set_complete_function(replCompleter)
+        return readline
       end
 end
 
@@ -163,7 +162,7 @@ if arg[1] == "--repl" or #arg == 0 then
         end
     end
 
-    tryReadline(options)
+    local readline = tryReadline(options)
 
     if options.fennelrc ~= false then
         local home = os.getenv("HOME")
@@ -187,6 +186,8 @@ if arg[1] == "--repl" or #arg == 0 then
         print("Use (doc something) to view documentation.")
     end
     fennel.repl(options)
+    -- if readline loaded, persist history (noop if histfile == '')
+    if readline then readline.save_history() end
 elseif arg[1] == "--compile" then
     for i = 2, #arg do
         local f = arg[i] == "-" and io.stdin or assert(io.open(arg[i], "rb"))

--- a/fennel
+++ b/fennel
@@ -117,8 +117,12 @@ end
 
 -- Try to load readline library
 local function tryReadline(opts)
-    local ok, readline = pcall(require, "readline")
-    if ok then
+    local readline_ok, readline = pcall(require, "readline")
+    if readline_ok then
+        if readline.set_readline_name then -- added as of readline.lua 2.6-0
+            readline.set_readline_name('fennel')
+        end
+
         readline.set_options({
             keeplines = 1000
         })


### PR DESCRIPTION
This addresses most of the enhancements in #236 

Enhances the support for libreadline when [readline.lua](https://luarocks.org/modules/peterbillam/readline) ([docs on website](https://pjb.com.au/comp/lua/readline.html) is installed:

- Opt-in support for persistent history by setting `histfile` option in `.fennelrc` e.g.
  ```clojure
  (when package.loaded.readline
    (package.loaded.readline.set_options {:histfile "~/.fennel_history"}))
  ```
  This will auto-save the rolling history when fennel exits (defaults to a noop when `histfile == ''`) and auto-load it when a REPL is started, supporting `ctrl+r` for history search and up/down for browsing between RPEL sessions.
- Set application name to `fennel` when `readline.lua` >= `2.6`
  This allows conditional options, specific to the fennel REPL, to be set in `~/.inputrc`, for example:
  ```inputrc
  $if fennel
    set blink-matching-paren On
    set enable-bracketed-paste On
  $endif
  ```
  See the [readline init file documentation](https://www.gnu.org/software/bash/manual/html_node/Readline-Init-File-Syntax.html#Readline-Init-File-Syntax) for available options.

I [submitted a patch](https://gitlab.com/peterbillam/pjb_lua/-/merge_requests/1) for setting the application name to `readline.lua` that was published in version 2.6, so the conditional directive support will start in that version.