### PR TITLE
Vararg limiting macros

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Add support for __fennelview metamethod for custom serialization
 * Fix a bug where `dofile` would report the wrong filename
 * Fix bug causing failing `include` of Lua modules that lack a trailing newline (#234)
+- Introduce `limit-values` and `limit-args` macros (#246)
 
 ## 0.3.2 / 2020-01-14
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -2771,6 +2771,21 @@ Same as ->> except will short-circuit with nil when it encounters a nil value."
             (let [body (list f ...)]
               (table.insert body _VARARG)
               `(fn [,_VARARG] ,body)))
+ :limit-args (fn [n f]
+               "Returns a function that passes only the first n arguments to f."
+               (assert (and (= (type n) :number) (= n (math.floor n)) (>= n 0))
+                 "Expected n to be an integer literal >= 0.")
+               (let [bindings []]
+                 (for [i 1 n] (tset bindings i (gensym)))
+                 `(fn ,bindings (,f ,(unpack bindings)))))
+ :limit-values (fn [n ...]
+                 "Limits values to the first n items. Useful for restricting multiple returns."
+                 (assert (and (= :number (type n)) (>= n 0) (= n (math.floor n)))
+                         "Expected n to be an integer >= 0")
+                 (let [bindings `()]
+                   (for [i 1 n] (table.insert bindings (gensym)))
+                   (if (= n 0) `(values)
+                       `(let [,bindings ,...] (values ,(unpack bindings))))))
  :lambda (fn [...]
            "Function literal with arity checking.
 Will throw an exception if a declared argument is passed in as nil, unless

--- a/reference.md
+++ b/reference.md
@@ -134,9 +134,41 @@ Example:
 (partial (fn [x y] (print (+ x y))) 2)
 ```
 
-
 This example returns a function which will print a number that is 2
 greater than the argument it is passed.
+
+### `limit-values` limit varargs/multiple returns to the first n values
+
+Discard all values after the first n when dealing, with multi-values, `...`,
+and multiple returns. Useful for composing functions that return multiple values
+with variadic functions.
+
+Example:
+
+```fennel
+(limit-values 0 :a :b :c :d :e) ; => nil
+[(limit-values 2 (table.unpack [:a :b :c]))] ;-> ["a" "b"]
+
+(fn sum-all [x y ...]
+  (let [x (or x 0) y (or y 0)]
+    (if (= (select :# ...) 0) (+ x y) (sum-all (+ x y) ...))))
+
+(sum-all (limit-values 2 (values 10 10))) ; => 20
+(->> [1 2 3 4 5] (table.unpack) (limit-values 3) (sum-all)) ; => 6
+```
+
+### `limit-args` wrap a function to accept only first n arguments
+
+Like `limit-values`, but takes an integer, `n`, and a function or other operation,
+f, and creates a new function that invokes `f` with only the first n arguments.
+
+Example:
+
+```fennel
+(local sum-2 (limit-args 2 sum-all))
+(sum-2 5 5 5 5) ; => 10
+(-> [1 2 3 4 5] (table.unpack) ((limit-args 3 sum-all))) ; => 6
+```
 
 ## Binding
 

--- a/reference.md
+++ b/reference.md
@@ -139,7 +139,7 @@ greater than the argument it is passed.
 
 ### `limit-values` limit varargs/multiple returns to the first n values
 
-Discard all values after the first n when dealing, with multi-values, `...`,
+Discard all values after the first n when dealing with multi-values (`...`)
 and multiple returns. Useful for composing functions that return multiple values
 with variadic functions.
 

--- a/test/core.lua
+++ b/test/core.lua
@@ -92,6 +92,12 @@ local function test_functions()
         ["(let [add (fn [x y] (+ x y)) inc (partial add 1)] (inc 99))"]=100,
         ["(let [add (fn [x y z] (+ x y z)) f2 (partial add 1 2)] (f2 6))"]=9,
         ["(let [add (fn [x y] (+ x y)) add2 (partial add)] (add2 99 2))"]=101,
+        -- limit-args
+        ["(let [f (fn [...] [...]) f-2 (limit-args 2 f)] (f-2 1 2 3))"]={1,2},
+        ["(let [f (fn [...] [...]) f-0 (limit-args 0 f)] (f-0 :foo))"]={},
+        -- limit-values
+        ["(let [f #(values :a :b :c)] [(limit-values 2 (f))])"]={'a','b'},
+        ["[(limit-values 0 (values 1 2 3 4 5))]"]={},
         -- functions with empty bodies return nil
         ["(if (= nil ((fn [a]) 1)) :pass :fail)"]="pass",
         -- basic lambda


### PR DESCRIPTION
This adds two new macros, `limit-args` and `limit-values`.

## Why both?

Strictly speaking, we could probably get away with just `limit-values`, but the one that generates a new function was also in demand and covers a common use-case for wrapping functions.

Still, open to feedback on whether we really need both as part of the language.

## The macros

### `(limit-values n ...)`

This operates on multiple values (passed directly, multiple returns from a function, `...`, etc) and returns the first n values only the first n. Useful in a number of scenarios to cap the values when passing around function invocations.

```clojure
(limit-values 0 :a :b :c :d :e) ; => nil
[(limit-values 2 (table.unpack [:a :b :c]))] ;-> ["a" "b"]

(fn sum-all [x y ...]
  (let [x (or x 0) y (or y 0)]
    (if (= (select :# ...) 0) (+ x y) (sum-all (+ x y) ...))))

(sum-all (limit-values 2 (values 10 10))) ; => 20
(->> [1 2 3 4 5] (table.unpack) (limit-values 3) (sum-all)) ; => 6
```

### `(limit-args n f)`

Like `limit-values`, but it wraps a function (or operator, or any expression) with a function that only passes along first n values. Useful for function composition, or for quickly doing `(fn [a b] (func a b))` for variadic functions that could receive bad input wen the varargs are left unchecked.

```clojure
(local sum-2 (limit-args 2 sum-all))
(sum-2 5 5 5 5) ; => 10
(-> [1 2 3 4 5] (table.unpack) ((limit-args 3 sum-all))) ; => 6
```