### PR TITLE
Add bitwise operators.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Summary of user-visible changes
 
 ## ??? / ???
-
+* Add bit-wise operators `>>`, `<<`, `|`, `&`, `bnot`, and `xor`
 * Add support for __fennelview metamethod for custom serialization
 * Fix a bug where `dofile` would report the wrong filename
 * Fix bug causing failing `include` of Lua modules that lack a trailing newline (#234)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1929,8 +1929,8 @@ SPECIALS["hashfn"] = function(ast, scope, parent)
 end
 docSpecial("hashfn", {"..."}, "Function literal shorthand; args are $1, $2, etc.")
 
-local function defineArithmeticSpecial(name, zeroArity, unaryPrefix)
-    local paddedOp = ' ' .. name .. ' '
+local function defineArithmeticSpecial(name, zeroArity, unaryPrefix, luaName)
+    local paddedOp = ' ' .. (luaName or name) .. ' '
     SPECIALS[name] = function(ast, scope, parent)
         local len = #ast
         if len == 1 then
@@ -1967,6 +1967,12 @@ defineArithmeticSpecial('*', '1')
 defineArithmeticSpecial('%')
 defineArithmeticSpecial('/', nil, '1')
 defineArithmeticSpecial('//', nil, '1')
+defineArithmeticSpecial('>>', nil, '1')
+defineArithmeticSpecial('<<', nil, '1')
+defineArithmeticSpecial('&', '0', '0')
+defineArithmeticSpecial('|', '0', '0')
+defineArithmeticSpecial('xor', '0', '0', '~')
+
 defineArithmeticSpecial('or', 'false')
 defineArithmeticSpecial('and', 'true')
 
@@ -2022,6 +2028,9 @@ end
 
 defineUnarySpecial("not", "not ")
 docSpecial("not", {"x"}, "Logical operator; works the same as Lua.")
+
+defineUnarySpecial("bnot", "~")
+docSpecial("bnot", {"x"}, "Bitwise negation; only works in Lua 5.3")
 
 defineUnarySpecial("length", "#")
 docSpecial("length", {"x"}, "Returns the length of a table or string.")

--- a/tutorial.md
+++ b/tutorial.md
@@ -121,7 +121,10 @@ nested `let`-like equivalent of `var`.
 Of course, all our standard arithmetic operators like `+`, `-`, `*`,
 and `/` work here in prefix form. Note that numbers are
 double-precision floats in all Lua versions prior to 5.3, which optionally
-introduced integers. On 5.3 and up, integer division uses `//`.
+introduced integers. On 5.3 and up, integer division uses `//` and bit-wise
+operations use `>>`, `<<`, `|`, `&`, as in Lua. Bit-wise not and exclusive or
+are `bnot` and `xor`. Bit-wise operators and integer division will not work
+if the host Lua environment is older than version 5.3.
 
 You may also use underscores to separate sections of long numbers. The
 underscores have no effect on the output.


### PR DESCRIPTION
Uses 5.3 bitwise operators with no shims for other Lua versions.

So I actually wrote this about a week ago and forgot to push it or request review - this is really simple way to add bitwise operators(no shims) and uses the same syntax as Lua for them - with the exceptions of bitwise not and exclusive or, which already have meanings in Fennel.