### PR TITLE
Preserve source data on quoted forms

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -2189,7 +2189,10 @@ local function doQuote (form, scope, parent, runtime)
     -- table
     elseif type(form) == 'table' then
         local mapped = kvmap(form, entryTransform(q, q))
-        return '{' .. mixedConcat(mapped, ", ") .. '}'
+        local source = getmetatable(form)
+        local filename = source.filename and ("'%s'"):format(source.filename)
+        return ("setmetatable({%s}, {filename=%s, line=%s})"):
+            format(mixedConcat(mapped, ", "), filename, source and source.line)
     -- string
     elseif type(form) == 'string' then
         return serializeString(form)

--- a/fennel.lua
+++ b/fennel.lua
@@ -2187,7 +2187,9 @@ local function doQuote (form, scope, parent, runtime)
     elseif isList(form) then
         assertCompile(not runtime, "lists may only be used at compile time", form)
         local mapped = kvmap(form, entryTransform(no, q))
-        return 'list(' .. mixedConcat(mapped, ", ") .. ')'
+        local filename = form.filename and ("'%s'"):format(form.filename) or "nil"
+        local s = "(function(l) l.filename, l.line = %s, %s return l end)(list(%s))"
+        return (s):format(filename, form.line or "nil", mixedConcat(mapped, ", "))
     -- table
     elseif type(form) == 'table' then
         local mapped = kvmap(form, entryTransform(q, q))

--- a/test/quoting.lua
+++ b/test/quoting.lua
@@ -20,6 +20,15 @@ local function test_quote()
     l.assertTrue(compiled == "return {[\"a\"]=5, [\"b\"]=9}" or
                      compiled == "return {[\"b\"]=9, [\"a\"]=5}",
                  "quoted keyed table")
+
+    -- syms have source data
+    c("\n\n(eval-compiler (set _G.source-line (. `abc :line)))")
+    l.assertEquals(_G["source-line"], 3)
+    -- autogensyms have source data
+    c("\n(eval-compiler (set _G.source-line (. `abc# :line)))")
+    l.assertEquals(_G["source-line"], 2)
+    -- lists have source data
+    -- tables have source data
 end
 
 return {test_quote=test_quote}

--- a/test/quoting.lua
+++ b/test/quoting.lua
@@ -34,7 +34,7 @@ local function test_quoted_source()
 
     c("\n\n\n(eval-compiler (set _G.source-line (. `(abc) :line)))")
     -- TODO: this one's hard!
-    -- l.assertEquals(_G["source-line"], 4, "lists have source data")
+    l.assertEquals(_G["source-line"], 4, "lists have source data")
 
     local _, msg = pcall(c, "\n\n\n\n(macro abc [] `(fn [... a#] 1)) (abc)")
     l.assertStrContains(msg, "unknown:5", "quoted tables have source data")

--- a/test/quoting.lua
+++ b/test/quoting.lua
@@ -1,34 +1,43 @@
 local l = require("luaunit")
 local fennel = require("fennel")
+local fennelview = require("fennelview")
 
 local function c(code)
     return fennel.compileString(code, {allowedGlobals=false})
+end
+
+local function v(code)
+    return fennelview(fennel.loadCode(c(code), _G)(), {["one-line"]=true})
 end
 
 local function test_quote()
     l.assertEquals(c('`:abcde'), "return \"abcde\"", "simple string quoting")
     l.assertEquals(c(',a'), "return unquote(a)",
                    "unquote outside quote is simply passed thru")
-    l.assertEquals(c('`[1 2 ,(+ 1 2) 4]'), "return {1, 2, (1 + 2), 4}",
+    l.assertEquals(v('`[1 2 ,(+ 1 2) 4]'), "[1 2 3 4]",
                    "unquote inside quote leads to evaluation")
-    l.assertEquals(c('(let [a (+ 2 3)] `[:hey ,(+ a a)])'),
-                   "local a = (2 + 3)\nreturn {\"hey\", (a + a)}",
+    l.assertEquals(v('(let [a (+ 2 3)] `[:hey ,(+ a a)])'), '["hey" 10]',
                    "unquote inside other forms")
-    l.assertEquals(c('`[:a :b :c]'), "return {\"a\", \"b\", \"c\"}",
+    l.assertEquals(v('`[:a :b :c]'), '[\"a\" \"b\" \"c\"]',
                    "quoted sequential table")
-    local compiled = c('`{:a 5 :b 9}')
-    l.assertTrue(compiled == "return {[\"a\"]=5, [\"b\"]=9}" or
-                     compiled == "return {[\"b\"]=9, [\"a\"]=5}",
-                 "quoted keyed table")
-
-    -- syms have source data
-    c("\n\n(eval-compiler (set _G.source-line (. `abc :line)))")
-    l.assertEquals(_G["source-line"], 3)
-    -- autogensyms have source data
-    c("\n(eval-compiler (set _G.source-line (. `abc# :line)))")
-    l.assertEquals(_G["source-line"], 2)
-    -- lists have source data
-    -- tables have source data
+    local viewed = v('`{:a 5 :b 9}')
+    l.assertTrue(viewed == "{:a 5 :b 9}" or viewed == "{:b 9 :a 5}",
+                 "quoted keyed table: " .. viewed)
 end
 
-return {test_quote=test_quote}
+local function test_quoted_source()
+    c("\n\n(eval-compiler (set _G.source-line (. `abc :line)))")
+    l.assertEquals(_G["source-line"], 3, "syms have source data")
+
+    c("\n(eval-compiler (set _G.source-line (. `abc# :line)))")
+    l.assertEquals(_G["source-line"], 2, "autogensyms have source data")
+
+    c("\n\n\n(eval-compiler (set _G.source-line (. `(abc) :line)))")
+    -- TODO: this one's hard!
+    -- l.assertEquals(_G["source-line"], 4, "lists have source data")
+
+    local ok, msg = pcall(c, "\n\n\n\n(macro abc [] `(fn [... a#] 1)) (abc)")
+    l.assertStrContains(msg, "unknown:5", "quoted tables have source data")
+end
+
+return {test_quote=test_quote, test_quoted_source=test_quoted_source}

--- a/test/quoting.lua
+++ b/test/quoting.lua
@@ -36,7 +36,7 @@ local function test_quoted_source()
     -- TODO: this one's hard!
     -- l.assertEquals(_G["source-line"], 4, "lists have source data")
 
-    local ok, msg = pcall(c, "\n\n\n\n(macro abc [] `(fn [... a#] 1)) (abc)")
+    local _, msg = pcall(c, "\n\n\n\n(macro abc [] `(fn [... a#] 1)) (abc)")
     l.assertStrContains(msg, "unknown:5", "quoted tables have source data")
 end
 


### PR DESCRIPTION
This fixes #253 for symbols, autogensyms, and tables inside quote by generating Lua that sets the source metadata on the values emitted.

It does not yet fix the problem for quoted lists, because of how lists are generated. Quoting a symbol results in a call to the function `sym` which takes three args, the name, the scope, and a table for source details. So splicing source details in is easy. Quoting a list results in a call to `list`, a function whose only arguments are the elements of the list itself.

**Edit**: fixed it for lists too.