### PR TITLE
rename limit-values/limit-args to pick-values/pick-args

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,10 +5,10 @@
 * Add bit-wise operators `>>`, `<<`, `|`, `&`, `bnot`, and `xor`
 * Friendlier compiler/parse error messages with suggestions
 * Omit compiler internal stack traces by default unless `FENNEL_DEBUG=trace`
-* Add support for __fennelview metamethod for custom serialization
+* Add support for `__fennelview` metamethod for custom serialization
 * Fix a bug where `dofile` would report the wrong filename
 * Fix bug causing failing `include` of Lua modules that lack a trailing newline (#234)
-- Introduce `limit-values` and `limit-args` macros (#246)
+* Introduce `pick-values` and `pick-args` macros (as `limit-*`: #246, as `pick-*`: #256)
 
 ## 0.3.2 / 2020-01-14
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -2847,7 +2847,7 @@ expands to\n\t(fn [_0_ _1_] (func _0_ _1_))"
                  `(fn ,bindings (,f ,(unpack bindings)))))
  :pick-values (fn [n ...]
                  "Like the `values` special, but emits exactly n values.\nFor example,
-\t(pick-values 2 ...)\nexpands to\n\t(let [(_0_ _1_) (values ...)] (values _0_ _1_))"
+\t(pick-values 2 ...)\nexpands to\n\t(let [(_0_ _1_) ...] (values _0_ _1_))"
                  (assert (and (= :number (type n)) (>= n 0) (= n (math.floor n)))
                          "Expected n to be an integer >= 0")
                  (let [let-syms   (list)

--- a/fennel.lua
+++ b/fennel.lua
@@ -2836,15 +2836,18 @@ Same as ->> except will short-circuit with nil when it encounters a nil value."
             (let [body (list f ...)]
               (table.insert body _VARARG)
               `(fn [,_VARARG] ,body)))
- :limit-args (fn [n f]
-               "Returns a function that passes only the first n arguments to f."
+ :pick-args (fn [n f]
+               "Creates a function of arity n that applies its arguments to f.
+For example,\n\t(pick-args 2 func)
+expands to\n\t(fn [_0_ _1_] (func _0_ _1_))"
                (assert (and (= (type n) :number) (= n (math.floor n)) (>= n 0))
                  "Expected n to be an integer literal >= 0.")
                (let [bindings []]
                  (for [i 1 n] (tset bindings i (gensym)))
                  `(fn ,bindings (,f ,(unpack bindings)))))
- :limit-values (fn [n ...]
-                 "Limits values to the first n items. Useful for restricting multiple returns."
+ :pick-values (fn [n ...]
+                 "Like the `values` special, but emits exactly n values.\nFor example,
+\t(pick-values 2 ...)\nexpands to\n\t(let [(_0_ _1_) (values ...)] (values _0_ _1_))"
                  (assert (and (= :number (type n)) (>= n 0) (= n (math.floor n)))
                          "Expected n to be an integer >= 0")
                  (let [let-syms   (list)

--- a/test/core.lua
+++ b/test/core.lua
@@ -92,13 +92,14 @@ local function test_functions()
         ["(let [add (fn [x y] (+ x y)) inc (partial add 1)] (inc 99))"]=100,
         ["(let [add (fn [x y z] (+ x y z)) f2 (partial add 1 2)] (f2 6))"]=9,
         ["(let [add (fn [x y] (+ x y)) add2 (partial add)] (add2 99 2))"]=101,
-        -- limit-args
-        ["(let [f (fn [...] [...]) f-2 (limit-args 2 f)] (f-2 1 2 3))"]={1,2},
-        ["(let [f (fn [...] [...]) f-0 (limit-args 0 f)] (f-0 :foo))"]={},
-        -- limit-values
-        ["(let [f #(values :a :b :c)] [(limit-values 2 (f))])"]={'a','b'},
-        ["[(limit-values 2 :a :b :c (values :d :e))]"]={'a','b'},
-        ["[(limit-values 0 (values 1 2 3 4 5))]"]={},
+        -- pick-args
+        ["(let [f (fn [...] [...]) f-2 (pick-args 2 f)] (f-2 1 2 3))"]={1,2},
+        ["(let [f (fn [...] [...]) f-0 (pick-args 0 f)] (f-0 :foo))"]={},
+        ["((pick-args 5 (partial select :#)))"] = 5,
+        -- pick-values
+        ["[(pick-values 4 :a :b :c (values :d :e))]"]={'a','b','c','d'},
+        ["(let [f #(values :a :b :c)] [(pick-values 0 (f))])"]={},
+        ["(select :# (pick-values 3))"]=3,
         -- functions with empty bodies return nil
         ["(if (= nil ((fn [a]) 1)) :pass :fail)"]="pass",
         -- basic lambda


### PR DESCRIPTION
Renamed `limit-values`/`limit-args` to `pick-values`/`pick-args` and updated the changelog and reference.

@technomancy:, the examples in the reference are significantly different from the ones you commented on (with the redundant `(select :# ...)`) in an earlier version of this branch; I realized the other examples, with `[(pick-values 3 :a :b)] ; => [:a :b nil]` were incorrect, since sequences do nothing with trailing nils.

## example when n > # values
I added an example of this to `pick-values` in the reference, to provide a heads up on possible bugs arising from `n` being greater than the number of values passed. I didn't add the same note to `pick-args`, but I did make sure one of the examples illustrated this.

## docstring formatting

I also tweaked the formatting of the docstrings so their output in the repl appears like:

```
>> (doc pick-values)
(pick-values n ...)
  Like the `values` special, but emits exactly n values.
  For example,
  	(pick-values 2 ...)
  expands to
  	(let [(_0_ _1_) (values ...)] (values _0_ _1_))

>> (doc pick-args)
(pick-args n f)
  Creates a function of arity n that applies its arguments to f.
  For example,
  	(pick-args 2 func)
  expands to
  	(fn [_0_ _1_] (func _0_ _1_))
```