### PR TITLE
Macro expander

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -2619,9 +2619,6 @@ local function makeCompilerEnv(ast, scope, parent)
         end,
         ["macroexpand"] = function(form) return macroexpand(form, scope) end,
         ["macroexpand-1"] = function(form) return macroexpand(form, scope, 1) end,
-        ["macroprint"] = function(form, view)
-            print((view or require("fennelview"))(macroexpand(form, scope)))
-        end,
     }, { __index = _ENV or _G })
 end
 
@@ -2892,6 +2889,9 @@ that argument name begins with ?."
           (assert (sym? name) "expected symbol for macro name")
           (local args [...])
           `(macros { ,(tostring name) (fn ,name ,(unpack args))}))
+ :macrodebug (fn macrodebug [form]
+              `(print ,((or (pcall require :fennelvieww) tostring)
+                        (macroexpand form _SCOPE))))
  :match
 (fn match [val ...]
   "Perform pattern matching on val. See reference for details."

--- a/fennel.lua
+++ b/fennel.lua
@@ -2619,6 +2619,9 @@ local function makeCompilerEnv(ast, scope, parent)
         end,
         ["macroexpand"] = function(form) return macroexpand(form, scope) end,
         ["macroexpand-1"] = function(form) return macroexpand(form, scope, 1) end,
+        ["macroprint"] = function(form, view)
+            print((view or require("fennelview"))(macroexpand(form, scope)))
+        end,
     }, { __index = _ENV or _G })
 end
 

--- a/reference.md
+++ b/reference.md
@@ -833,6 +833,30 @@ about the functions available here.
 If you are only defining a single macro, this is equivalent to the
 previous example. The syntax mimics `fn`.
 
+### `macrodebug` print the expansion of a macro
+
+```fennel
+(macrodebug (-> abc
+                (+ 99)
+                (> 0)
+                (when (os.exit))))
+; -> (if (> (+ abc 99) 0) (do (os.exit)))
+```
+
+Call the `macrodebug` macro with a form and it will expand all the
+macros in that form and print out the resulting form. Note that the
+resulting form will usually not be sensibly indented, so you might
+need to copy it and reformat it into something more readable.
+
+It will attempt to load the `fennelview` module to pretty-print the
+results but will fall back to `tostring` if that isn't found. If you
+have moved the `fennelview` module to another location, try setting it
+in `package.loaded` to make it available here:
+
+```fennel
+(set package.loaded (require :lib.newlocation.fennelview))
+```
+
 ### Macro gotchas
 
 It's easy to make macros which accidentally evaluate their arguments
@@ -923,12 +947,6 @@ and a metatable that the compiler uses to distinguish them. You can use
 * `in-scope?` - does this symbol refer to an in-scope local? (works in macros only)
 * `macroexpand` - performs macroexpansion on its argument form; returns an AST
 * `macroexpand-1` - performs one level of macroexpansion on its argument
-* `macroprint` - performs macroexpansion and prints the result for debugging
-
-The `macroprint` function will attempt to load the `fennelview` module
-in order to print the expanded AST; if this is not available it will
-fail unless you provide a second argument to use as a pretty printer
-instead. In a pinch, `tostring` will work on some forms.
 
 Note that other internals of the compiler exposed in compiler scope are
 subject to change.

--- a/reference.md
+++ b/reference.md
@@ -560,7 +560,7 @@ Example:
 *(Changed in 0.3.0: the function was called `#` before.)*
 
 Returns the length of a string or table. Note that the length of a
-table with gaps in it is undefined; it can return a number
+table with gaps (nils) in it is undefined; it can return a number
 corresponding to any of the table's "boundary" positions between nil
 and non-nil values. If a table has nils and you want to know the last
 consecutive numeric index starting at 1, you must calculate it
@@ -593,8 +593,8 @@ Example:
 ```
 
 
-Note that if the field name is known at compile time, you don't need
-this and can just use `mytbl.field`.
+Note that if the field name is a string known at compile time, you
+don't need this and can just use `mytbl.field`.
 
 ### `:` method call
 
@@ -730,7 +730,31 @@ the next form.
 The first form becomes the return value for the whole expression, and
 subsequent forms are evaluated solely for side-effects.
 
-### `require-macros`
+### `include`
+
+*(since 0.3.0)*
+
+```fennel
+(include :my.embedded.module)
+```
+Load Fennel/Lua module code at compile time and embed it, along with any modules *it*
+requires, etc., in the compiled output. The module name must be a string literal
+that can resolve to a module during compilation. The bundled code will be wrapped
+in a function invocation in the emitted Lua.
+
+See also: the `requireAsInclude` option in the API documentation and the `--require-as-include`
+CLI flag (`fennel --help`)
+
+## Macros
+
+Note that the macro interface is still preliminary and is subject to
+change over time.
+
+All forms which introduce macros do so inside the current scope. This
+is usually the top level for a given file, but you can introduce
+macros into smaller scopes as well.
+
+### `require-macros` load macros from a separate module
 
 Requires a module at compile-time and binds its fields locally as macros.
 
@@ -778,18 +802,15 @@ into the backtick template:
 See "Compiler API" below for details about additional functions visible
 inside compiler scope which macros run in.
 
-Note that the macro interface is still preliminary and is subject to
-change over time.
-
-### `macros`
+### `macros` define several macros
 
 *(Since 0.3.0)*
 
-Defines a table of macros local to the current fennel file. Note that
-inside the macro definitions, you cannot access variables and bindings
-from the surrounding code. The macros are essentially compiled in their
-own compiler environment. Again, see the "Compiler API" section for
-more details about the macro interface.
+Defines a table of macros. Note that inside the macro definitions, you
+cannot access variables and bindings from the surrounding code. The
+macros are essentially compiled in their own compiler
+environment. Again, see the "Compiler API" section for more details
+about the functions available here.
 
 ```fennel
 (macros {:my-max (fn [x y]
@@ -800,6 +821,17 @@ more details about the macro interface.
 (print (my-max 20 10))
 (print (my-max 20 20))
 ```
+
+### `macro` define a single macro
+
+```fennel
+(macro my-max [x y]
+  `(let [x# ,x y# ,y]
+     (if (< x# y#) y# x#)))
+```
+
+If you are only defining a single macro, this is equivalent to the
+previous example. The syntax mimics `fn`.
 
 ### Macro gotchas
 
@@ -850,21 +882,6 @@ allow the macro to be called, it will fail trying to call a global
 ; Compile error in 'my-max': attempt to call global '__fnl_global__my_2dfn' (a nil value)
 ```
 
-### `include`
-
-*(since 0.3.0)*
-
-```fennel
-(include :my.embedded.module)
-```
-Load Fennel/Lua module code at compile time and embed it, along with any modules *it*
-requires, etc., in the compiled output. The module name must be a string literal
-that can resolve to a module during compilation. The bundled code will be wrapped
-in a function invocation in the emitted Lua.
-
-See also: the `requireAsInclude` option in the API documentation and the `--require-as-include`
-CLI flag (`fennel --help`)
-
 ### `eval-compiler`
 
 Evaluate a block of code during compile-time with access to compiler
@@ -875,8 +892,11 @@ Example:
 
 ```fennel
 (eval-compiler
-  (tset _SPECIALS "local" (. _SPECIALS "global")))
+  (each [name (pairs _G)]
+    (print name)))
 ```
+
+This prints all the functions available in compiler scope.
 
 ### Compiler API
 
@@ -901,6 +921,14 @@ and a metatable that the compiler uses to distinguish them. You can use
 * `varg?` - is this a `...` symbol which indicates var args?
 * `multi-sym?` - a multi-sym is a dotted symbol which refers to a table's field
 * `in-scope?` - does this symbol refer to an in-scope local? (works in macros only)
+* `macroexpand` - performs macroexpansion on its argument form; returns an AST
+* `macroexpand-1` - performs one level of macroexpansion on its argument
+* `macroprint` - performs macroexpansion and prints the result for debugging
+
+The `macroprint` function will attempt to load the `fennelview` module
+in order to print the expanded AST; if this is not available it will
+fail unless you provide a second argument to use as a pretty printer
+instead. In a pinch, `tostring` will work on some forms.
 
 Note that other internals of the compiler exposed in compiler scope are
 subject to change.

--- a/reference.md
+++ b/reference.md
@@ -843,10 +843,10 @@ previous example. The syntax mimics `fn`.
 ; -> (if (> (+ abc 99) 0) (do (os.exit)))
 ```
 
-Call the `macrodebug` macro with a form and it will expand all the
-macros in that form and print out the resulting form. Note that the
-resulting form will usually not be sensibly indented, so you might
-need to copy it and reformat it into something more readable.
+Call the `macrodebug` macro with a form and it will repeatedly expand
+top-level macros in that form and print out the resulting form. Note
+that the resulting form will usually not be sensibly indented, so you
+might need to copy it and reformat it into something more readable.
 
 It will attempt to load the `fennelview` module to pretty-print the
 results but will fall back to `tostring` if that isn't found. If you
@@ -944,9 +944,12 @@ and a metatable that the compiler uses to distinguish them. You can use
 * `gensym` - generates a unique symbol for use in macros.
 * `varg?` - is this a `...` symbol which indicates var args?
 * `multi-sym?` - a multi-sym is a dotted symbol which refers to a table's field
-* `in-scope?` - does this symbol refer to an in-scope local? (works in macros only)
+
+These functions can be used from within macros only, not from any
+`eval-compiler` call:
+
+* `in-scope?` - does this symbol refer to an in-scope local?
 * `macroexpand` - performs macroexpansion on its argument form; returns an AST
-* `macroexpand-1` - performs one level of macroexpansion on its argument
 
 Note that other internals of the compiler exposed in compiler scope are
 subject to change.

--- a/test/core.lua
+++ b/test/core.lua
@@ -363,6 +363,12 @@ local function test_macros()
         ["(macros {:plus (fn [x y] `(+ ,x ,y))}) (plus 9 9)"]=18,
         -- Vararg in quasiquote
         ["(macros {:x (fn [] `(fn [...] (+ 1 1)))}) ((x))"]=2,
+        -- macro expanding to macro
+        ["(macros {:when2 (fn [c val] `(when ,c ,val))})\
+          (when2 true :when2)"]="when2",
+        -- macro expanding to indirect macro
+        ["(macros {:when3 (fn [c val] `(do (when ,c ,val)))})\
+          (when3 true :when3)"]="when3",
         -- Threading macro with single function, with and without parens
         ["(-> 1234 (string.reverse) (string.upper))"]="4321",
         ["(-> 1234 string.reverse string.upper)"]="4321",


### PR DESCRIPTION
This implements a first-class macroexpander in the form of `macroexpand`, `macroexpand-1`, and `macroprint`, the latter of which is intended to be used interactively for debugging.

Bonus: also improved the docs for other macro-related reference materials.

Edit: renamed to `macroprint` to `macrodebug` and made it automatically fall back to `tostring` if it can't fennelview, with a note for how to make it able to find fennelview in the reference.

Fixes #183.