### PR TITLE
make completion walk scope ancestors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
 * Set macros on scope.macros & add new `macroexpand` helper to expand macro forms during
 compilation rather than uplifting macros to specials. (#258)
 * Add `macrodebug` util macro for printing expanded macro forms in REPL. (#258)
+* Make completion walk scope ancestors for macros & specials (#260)
 
 ## 0.3.2 / 2020-01-14
 


### PR DESCRIPTION
The recent merge on master stopped macros from showing up in REPL readline.lua completion because it was pointing at `scope.macros` instead of `scope.parent.macros`, and I realized this would be more reliable if the completer simply walked ancestors for each table of candidates.

- Adds `allPairs` function that walks ancestors, skipping duplicate keys
- remove internals.SPECIALS from repl and add internals.allPairs
- modify the completion items cap from 40 to 2000; this will stop it
from blowing up, and let the frontend (e.g. readline) handle how many to
display.

Could use some feedback on changing the matches limit to 2000 - we could just remove it entirely. Readline has a (configurable) internal limit after which it will ask you if you want to display all N matches, and we can probably just let the frontend handle that aspect, but a limit will stop runaway iteration if something weird happens (circular inheritance, some clobbering of globals, etc).