### PR TITLE
fix tests to give proper exit code on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ LUA ?= lua
 test: fennel
 	$(LUA) test/init.lua
 
+testall: export FNL_TEST_OUTPUT ?= text
 testall: fennel
-	lua5.1 test/init.lua
-	lua5.2 test/init.lua
-	lua5.3 test/init.lua
-	luajit test/init.lua
+	@echo -e 'Testing lua 5.1:'  ; lua5.1 test/init.lua
+	@echo -e "\nTesting lua 5.2:"; lua5.2 test/init.lua
+	@echo -e "\nTesting lua 5.3:"; lua5.3 test/init.lua
+	@echo -e "\nTesting luajit:" ; luajit test/init.lua
 
 luacheck:
 	luacheck fennel.lua test/*.lua

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ test: fennel
 
 testall: export FNL_TEST_OUTPUT ?= text
 testall: fennel
-	@echo -e 'Testing lua 5.1:'  ; lua5.1 test/init.lua
-	@echo -e "\nTesting lua 5.2:"; lua5.2 test/init.lua
-	@echo -e "\nTesting lua 5.3:"; lua5.3 test/init.lua
-	@echo -e "\nTesting luajit:" ; luajit test/init.lua
+	@printf 'Testing lua 5.1:\n'  ; lua5.1 test/init.lua
+	@printf "\nTesting lua 5.2:\n"; lua5.2 test/init.lua
+	@printf "\nTesting lua 5.3:\n"; lua5.3 test/init.lua
+	@printf "\nTesting luajit:\n" ; luajit test/init.lua
 
 luacheck:
 	luacheck fennel.lua test/*.lua

--- a/test/init.lua
+++ b/test/init.lua
@@ -1,31 +1,40 @@
-local l = require("luaunit")
 -- prevent luarocks-installed fennel from overriding
 package.loaded.fennel = dofile("fennel.lua")
 table.insert(package.loaders or package.searchers, package.loaded.fennel.searcher)
 package.loaded.fennelview = package.loaded.fennel.dofile("fennelview.fnl")
 
--- luaunit wants the test suite in a really weird alist format
-local function test(moduleName)
-    local i = {}
-    for k,v in pairs(require(moduleName)) do
-        table.insert(i, {k, v})
+local lu, outputType = require('luaunit'), os.getenv('FNL_TEST_OUTPUT') or 'tap'
+local runner = lu.LuaUnit:new()
+runner:setOutputType(outputType)
+
+-- attach test modules (which export k/v tables of test fns) as alists
+local function addModule(instances, moduleName)
+    for k, v in pairs(require(moduleName)) do
+        instances[#instances + 1] = {k, v}
     end
-    print("Running", moduleName)
-    l.LuaUnit:runSuiteByInstances(i)
 end
 
--- these tests need to be in Lua; if anything here breaks, we can't even load
--- our tests that are written in Fennel.
-test("test.core")
-test("test.mangling")
-test("test.quoting")
-test("test.misc")
+local function testAll(testModules)
+    local instances = {}
+    for _, module in ipairs(testModules) do
+        addModule(instances, module)
+    end
+    return runner:runSuiteByInstances(instances)
+end
 
--- these can be in Fennel
-test("test.docstring")
-test("test.fennelview")
-test("test.failures")
-test("test.repl")
-test("test.cli")
+testAll({
+    -- these tests need to be in Lua; if anything here breaks
+    -- we can't even load our tests that are written in Fennel.
+    'test.core',
+    'test.mangling',
+    'test.quoting',
+    'test.misc',
+    -- these can be in fennel
+    'test.docstring',
+    'test.fennelview',
+    'test.failures',
+    'test.repl',
+    'test.cli',
+})
 
-os.exit(l.LuaUnit.result.notSuccessCount > 0 and 1 or 0)
+os.exit(runner.result.notSuccessCount == 0 and 0 or 1)


### PR DESCRIPTION
*EDIT: Updated this to avoid the pitfalls of self-hosting when we may want to use the tests to see where something breaks.*

I noticed that test/init.lua was running tests on each module separately, and that `make test` was giving a 0 exit code even when there were failing tests.

While we could have tweaked it to keep a running tally on failures in each module, I took the opportunity to:
- Build and run a *single* test suite
- Ensure a proper non-zero exit code when tests fail
- Modify default test output to default to TAP format (human- and machine-readable Test Anything Protocol), which shows a minimal line for each test in the suite.
- Make the test output format configurable via FNL_TEST_OUTPUT env var, so it can be set to anything LuaUnit supports
- Clean up output of `make testall` to show only summaries, while `make test` defaults to outputting TAP.