### PR TITLE
Fix macro args length calculation

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -1126,9 +1126,9 @@ local function compile1(ast, scope, parent, opts)
     -- Compile the form
     if isList(ast) then
         -- Function call or special form
-        local len = #ast
-        assertCompile(len > 0, "expected a function, macro, or special to call", ast)
+        assertCompile(#ast > 0, "expected a function, macro, or special to call", ast)
         ast = macroexpand(ast, scope)
+        local len = ast and #ast or 0
         -- Test for special form
         local first = type(ast) == "table" and ast[1]
         if isSym(first) then -- Resolve symbol

--- a/test/core.lua
+++ b/test/core.lua
@@ -340,6 +340,8 @@ local function test_macros()
         ["(-?> {:a {:b {:c :z}}} (. :a) (. :missing) (. :c))"]=nil,
         ["(-?>> :w (. {:w :x}) (. {:x :y}) (. {:y :z}))"]="z",
         ["(-?>> :w (. {:w :x}) (. {:x :missing}) (. {:y :z}))"]=nil,
+        ["(-?> [:a :b] (table.concat \" \"))"]="a b",
+        ["(-?>> \" \" (table.concat [:a :b]))"]="a b",
         -- just a boring old set+fn combo
         ["(require-macros \"test-macros\")\
           (defn1 hui [x y] (global z (+ x y))) (hui 8 4) z"]=12,


### PR DESCRIPTION
The ast length can change as part of macro expansion, so this PR delays this calculation until after macro expansion.

Fixes #276 