### PR TITLE
fix 0.4.0 macro expansion to primitives

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Summary of user-visible changes
 
+## 0.4.1 / ???
+
+* Fix a 0.4.0 bug where macros can't expand to string/boolean/number primitives (#279)
+
 ## 0.4.0 / 2020-05-12
 
 * Add `import-macros` for more flexible macro module loading (#269)

--- a/fennel.lua
+++ b/fennel.lua
@@ -1088,8 +1088,8 @@ local function macroexpand(ast, scope, once)
     local ok, transformed = pcall(macro, unpack(ast, 2))
     macroCurrentScope = oldScope
     assertCompile(ok, transformed, ast)
-    if once then return transformed end -- macroexpand-1
-    if transformed then return macroexpand(transformed, scope) end
+    if once or not transformed then return transformed end -- macroexpand-1
+    return macroexpand(transformed, scope)
 end
 
 -- Compile an AST expression in the scope into parent, a tree

--- a/test/core.lua
+++ b/test/core.lua
@@ -383,6 +383,10 @@ local function test_macros()
         ["(-> 1234 string.reverse string.upper)"]="4321",
         -- Auto-gensym
         ["(macros {:m (fn [y] `(let [xa# 1] (+ xa# ,y)))}) (m 4)"]=5,
+        -- macro expanding to primitives
+        ["(macro five [] 5) (five)"] = 5,
+        ["(macro greet [] :Hi!) (greet)"] = "Hi!",
+        ["(macro yes [] true) (yes)"] = true,
         -- Side-effecting macros
         ["(macros {:m (fn [x] (set _G.sided x))}) (m 952) _G.sided"]=952,
     }

--- a/test/core.lua
+++ b/test/core.lua
@@ -386,7 +386,7 @@ local function test_macros()
         -- macro expanding to primitives
         ["(macro five [] 5) (five)"] = 5,
         ["(macro greet [] :Hi!) (greet)"] = "Hi!",
-        ["(macro yes [] true) (yes)"] = true,
+        ["(macros {:yes (fn [] true) :no (fn [] false)}) [(yes) (no)]"]={true, false},
         -- Side-effecting macros
         ["(macros {:m (fn [x] (set _G.sided x))}) (m 952) _G.sided"]=952,
     }


### PR DESCRIPTION
Fixes #279 

This tweaks `compile1` so that, if `macroexpand` returns a different AST than the one passed in (signifying a macro was expanded), it makes a recursive tail call to `compile1` so that it can handle each `ast` type anew instead of being stuck in the `isList(ast)` branch. This should simplify things so we don't have to special-case every possible macro expansion.

Because changes to `compile1` is at a relatively high risk of causing regressions, this could probably use some extra review just to make sure I didn't break anything else in the process.