### PR TITLE
Save off source in rootOptions so fennelfriend can use it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ testall: fennel
 	@printf "\nTesting luajit:\n" ; luajit test/init.lua
 
 luacheck:
-	luacheck fennel.lua test/*.lua
+	luacheck fennel.lua test/init.lua test/mangling.lua \
+		test/misc.lua test/quoting.lua
 
 count:
 	cloc fennel.lua

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## 0.4.1 / ???
 
+* Pinpoint source in compile errors even when loading from a string
 * Fix a bug where included modules could get included twice
 * Fix a 0.4.0 bug where macros can't expand to string/boolean/number primitives (#279)
 * Fix a bug in macros returning forms of a different length from their input (#276)

--- a/fennel.lua
+++ b/fennel.lua
@@ -116,7 +116,7 @@ local function loadCode(code, environment, filename)
 end
 
 -- Safely load an environment variable
-local getenv = os and os.getenv or function() end
+local getenv = os and os.getenv or function() return nil end
 
 local function debugOn(flag)
     local level = getenv("FENNEL_DEBUG") or ""

--- a/fennelfriend.fnl
+++ b/fennelfriend.fnl
@@ -151,13 +151,27 @@
   (let [f (assert (io.open filename))
         _ (for [_ 1 (- line 1)]
             (set bytes (+ bytes 1 (# (f:read)))))
-        codeline (f:read)
-        eol (+ bytes (# codeline))]
+        codeline (f:read)]
     (f:close)
-    (values codeline bytes eol)))
+    (values codeline bytes)))
 
-(fn friendly-msg [msg {: filename : line : bytestart : byteend}]
-  (let [(ok codeline bol eol) (pcall read-line-from-file filename line)
+(fn read-line-from-source [source line]
+  (var (lines bytes codeline) (values 0 0))
+  (each [this-line (string.gmatch (.. source "\n") "(.-)\r?\n")]
+    (set lines (+ lines 1))
+    (when (= lines line)
+      (set codeline this-line)
+      (lua :break))
+    (set bytes (+ bytes 1 (# this-line))))
+  (values codeline bytes))
+
+(fn read-line [filename line source]
+  (if source
+      (read-line-from-source source line)
+      (read-line-from-file filename line)))
+
+(fn friendly-msg [msg {: filename : line : bytestart : byteend} source]
+  (let [(ok codeline bol eol) (pcall read-line filename line source)
         suggestions (suggest msg)
         out [msg ""]]
     ;; don't assume the file can be read as-is
@@ -167,7 +181,8 @@
     (when (and ok codeline bytestart byteend)
       (table.insert out (.. (string.rep " " (- bytestart bol 1)) "^"
                             (string.rep "^" (math.min (- byteend bytestart)
-                                                      (- eol bytestart))))))
+                                                      (- (+ bol (# codeline))
+                                                         bytestart))))))
     (when (and ok codeline bytestart (not byteend))
       (table.insert out (.. (string.rep "-" (- bytestart bol 1)) "^"))
       (table.insert out ""))
@@ -176,7 +191,7 @@
         (table.insert out (: "* Try %s." :format suggestion))))
     (table.concat out "\n")))
 
-(fn assert-compile [condition msg ast]
+(fn assert-compile [condition msg ast source]
   "A drop-in replacement for the internal assertCompile with friendly messages."
   (when (not condition)
     (let [{: filename : line} (ast-source ast)]
@@ -184,12 +199,12 @@
                               ;; still need fallbacks because backtick erases
                               ;; source data, and vararg has no source data
                               (or filename :unknown) (or line :?) msg)
-                           (ast-source ast)) 0)))
+                           (ast-source ast) source) 0)))
   condition)
 
-(fn parse-error [msg filename line bytestart]
+(fn parse-error [msg filename line bytestart source]
   "A drop-in replacement for the internal parseError with friendly messages."
   (error (friendly-msg (: "Parse error in %s:%s\n  %s" :format filename line msg)
-                       {: filename : line : bytestart}) 0))
+                       {: filename : line : bytestart} source) 0))
 
 {: assert-compile : parse-error}


### PR DESCRIPTION
Originally `fennelfriend` relied on having the source of the file on disk in order to pinpoint where the error was caused. This changes it so that it works when you're evaluating a string, not just a file on disk. This makes it work in the repl as well as in other contexts like TIC-80.

Are there any other entry points than compileString that should do this?

Is it necessary to save off the old options.source and restore it afterwards?