### PR TITLE
Fix nil inside quoted lists when macroexpanding

### DIFF
--- a/test/core.lua
+++ b/test/core.lua
@@ -389,6 +389,8 @@ local function test_macros()
         ["(macros {:yes (fn [] true) :no (fn [] false)}) [(yes) (no)]"]={true, false},
         -- Side-effecting macros
         ["(macros {:m (fn [x] (set _G.sided x))}) (m 952) _G.sided"]=952,
+        -- Macros returning nil in unquote
+        ["(import-macros m :test.macros) (var x 1) (m.inc! x 2) (m.inc! x) x"]=4,
     }
     for code,expected in pairs(cases) do
         l.assertEquals(fennel.eval(code, {correlate=true}), expected, code)

--- a/test/macros.fnl
+++ b/test/macros.fnl
@@ -9,4 +9,5 @@
           (assert (sym? name) "defn1: function names must be symbols")
           `(global ,name (fn ,args ,...)))
  :inc   (fn [n] (if (not (list? n)) `(+ ,n 1)
-                  `(let [num# ,n] (+ num# 1))))}
+                    `(let [num# ,n] (+ num# 1))))
+ :inc! (fn [a ?n] `(set ,a (+ ,a (or ,?n 1))))}


### PR DESCRIPTION
This causes quoted lists to be constructed the same way the parser constructs them; all in a single pass as a literal table, rather than constructing them with `list()` and setting the `filename`/`line` fields after the fact. It appears this setting of the fields causes something inside the implementation of the table to shift and cause `#` to give us unwanted values for the AST.

It doesn't *really* solve the problem of the undefined behavior of `#`, but it does mean that the problem applies consistently now regardless of how the AST was constructed, whether thru the parser or thru quoting.

Fixes #284 