### PR TITLE
Encode sequences in a way that's compatible with storing source data.

### DIFF
--- a/test/core.lua
+++ b/test/core.lua
@@ -391,6 +391,7 @@ local function test_macros()
         ["(macros {:m (fn [x] (set _G.sided x))}) (m 952) _G.sided"]=952,
         -- Macros returning nil in unquote
         ["(import-macros m :test.macros) (var x 1) (m.inc! x 2) (m.inc! x) x"]=4,
+        ["(macro seq? [expr] (sequence? expr)) (seq? [65])"]={65},
     }
     for code,expected in pairs(cases) do
         l.assertEquals(fennel.eval(code, {correlate=true}), expected, code)


### PR DESCRIPTION
Using SEQUENCE_MT as the same metatable for every single sequence ever
makes it so that you can't store file/line data on them. Instead we
set the metatable to a new table that includes SEQUENCE_MARKER.

Also adds the sequence constructor function to compiler scope.

Fixes #286 