### PR TITLE
Searcher package config

### DIFF
--- a/fennel.lua
+++ b/fennel.lua
@@ -2242,7 +2242,7 @@ local function doQuote (form, scope, parent, runtime)
         assertCompile(not runtime, "symbols may only be used at compile time", form)
         -- We should be able to use "%q" for this but Lua 5.1 throws an error
         -- when you try to format nil, because it's extremely bad.
-        local filename = form.filename and ("'%s'"):format(form.filename) or "nil"
+        local filename = form.filename and ('%q'):format(form.filename) or "nil"
         if deref(form):find("#$") then -- autogensym
             return ("sym('%s', nil, {filename=%s, line=%s})"):
                 format(autogensym(deref(form), scope), filename, form.line or "nil")
@@ -2259,7 +2259,7 @@ local function doQuote (form, scope, parent, runtime)
     elseif isList(form) then
         assertCompile(not runtime, "lists may only be used at compile time", form)
         local mapped = kvmap(form, entryTransform(no, q))
-        local filename = form.filename and ("'%s'"):format(form.filename) or "nil"
+        local filename = form.filename and ('%q'):format(form.filename) or "nil"
         -- Constructing a list and then adding file/line data to it triggers a
         -- bug where it changes the value of # for lists that contain nils in
         -- them; constructing the list all in one go with the source data and
@@ -2273,7 +2273,7 @@ local function doQuote (form, scope, parent, runtime)
     elseif type(form) == 'table' then
         local mapped = kvmap(form, entryTransform(q, q))
         local source = getmetatable(form)
-        local filename = source.filename and ("'%s'"):format(source.filename) or "nil"
+        local filename = source.filename and ('%q'):format(source.filename) or "nil"
         return ("setmetatable({%s}, {filename=%s, line=%s})"):
             format(mixedConcat(mapped, ", "), filename, source and source.line or "nil")
     -- string

--- a/fennel.lua
+++ b/fennel.lua
@@ -2639,8 +2639,8 @@ end
 
 local function searchModule(modulename, pathstring)
     -- use package.config to process package.path (e.g. for windows compat)
-    local pkgconfig = string.gmatch(package.config, "([^\n]+)")
-    local dirsep, pathsep, pathmark = pkgconfig(), pkgconfig(), pkgconfig()
+    local cfg = string.gmatch(package.config, "([^\n]+)")
+    local dirsep, pathsep, pathmark = cfg() or '/', cfg() or ';', cfg() or '?'
     local escapedSep = escapepat(pathsep)
     local pathsplit = string.format("([^%s]*)%s", escapedSep, escapedSep)
     modulename = modulename:gsub("%.", dirsep)


### PR DESCRIPTION
Fixes #290

For cross-platform compat, `package.config` contains info about what to use as a dir separator, a delimiter in the package.path list, what to use as a placeholder, etc. This change uses the first three `package.config` values in `searchModule`, which should allow "\" in `fennel.path` to work on Windows.

## Recalculating every time?

I initially put this logic in `searchModule` so that it's recalculated every time. However, because these values are set internally by the Lua VM during its "compile time" (see [Lua reference](https://www.lua.org/manual/5.3/manual.html#pdf-package.config) and [the Lua C source that sets it](https://github.com/lua/lua/blob/master/loadlib.c#L744-L746)), changes to `package.config` during runtime don't appear to impact `require` or `package.searchpath`; local testing in Lua seems to verify this.

## Testing

We can't really add automated tests for this unless we make circleci rerun tests in a Windows VM, but before merging we should see if someone can test this branch on a Windows machine to ensure it actually does address #290. 

**EDIT:** Even without windows, we can probably at least test the fix to `doQuote` that I just pushed by adding a dir with a backslash to `fennel.path`. I'm out of time to work on this until tonight or tomorrow, but if someone wants to add such a test and get this merged, feel free.