### PR TITLE
Document new install procedure with standalone binaries.

### DIFF
--- a/release-checklist.md
+++ b/release-checklist.md
@@ -10,7 +10,11 @@ is intended for Fennel maintainers.
 4. Make sure tests pass for all versions of Lua and the linter is OK (`make ci`)
 5. Commit above changes.
 6. Tag release with chosen git tag, and push to repository.
-7. Upload rock with `luarocks upload rockspecs/fennel-(version)-1.rockspec`. Fennel is now released!
-8. Update the submodule in the fennel-lang.org repository.
-9. Announce it on the mailing list.
-10. Bump the version in fennel.lua to the next version with a "-dev" suffix; add changelog stub.
+7. Create a release in GitHub; paste the changelog for this version.
+8. Upload rock with `luarocks upload rockspecs/fennel-(version)-1.rockspec`. Test that the new version can be installed thru LuaRocks. Fennel is now released!
+9. Update the submodule in the fennel-lang.org repository.
+10. Upload builds to https://fennel-lang.org/downloads (TODO: automate)
+11. Update the download links in `setup.md`.
+12. Announce it on the mailing list.
+13. Bump the version in fennel.lua to the next version with a "-dev" suffix; add changelog stub.
+

--- a/setup.md
+++ b/setup.md
@@ -7,13 +7,6 @@ edit configuration files in a UNIX-like environment.
 Fennel can be used in non-UNIX environments, but those environments
 will not be covered in this document.
 
-# Requirements
-
-* Access to a UNIX-like environment, such as Ubuntu, Debian, Arch
-  Linux, Windows Subsystem for Linux, Homebrew, scoop.sh, etc.
-* Lua version 5.1, 5.2, 5.3, or LuaJIT
-* LuaRocks or Git and Make
-
 # Downloading and installing Fennel
 
 Downloading and installing Fennel on your system allows you to run
@@ -22,12 +15,35 @@ Git or LuaRocks.
 
 Depending on which method you want to use, choose a subsection below:
 
+* [Installing directly](#installing-directly)
 * [Using Git to download Fennel](#using-git-to-download-and-install-fennel)
 * [Using LuaRocks to download Fennel](#using-luarocks-to-download-and-install-fennel)
 
 **Tip**: If you are using software that supports Fennel, such as
 [TIC-80](https://tic.computer), you do not need to download Fennel,
 because you can use it inside of TIC-80.
+
+## Installing directly
+
+If you have Lua (5.1, 5.2, 5.3, or LuaJIT) installed on your system
+you can download the Fennel script easily, but updates will have to be
+done manually.
+
+### To install directly
+
+1. Download [the fennel script](https://fennel-lang.org/downloads/fennel-0.4.1)
+3. Run `chmod +x fennel-0.4.1` to make it executable
+4. Download [the signature](https://fennel-lang.org/downloads/fennel-0.4.1.asc)
+5. Confirm it using `gpg --verify fennel-0.4.1.asc`
+3. Move `fennel-0.4.1` to a directory on your `$PATH`, such as `/usr/local/bin`
+
+You can rename the script to just `fennel` for convenience. If you
+don't have Lua installed, you can get one of the standalone binaries
+instead if there is one provided for your system:
+
+* [GNU/Linux x86_64](https://fennel-lang.org/downloads/fennel-0.4.1-x86_64) ([signature](https://fennel-lang.org/downloads/fennel-0.4.1-x86_64.asc))
+* [GNU/Linux arm32](https://fennel-lang.org/downloads/fennel-0.4.1-arm32) ([signature](https://fennel-lang.org/downloads/fennel-0.4.1-arm32.asc))
+* [Windows x86 32-bit](https://fennel-lang.org/downloads/fennel-0.4.1-windows32.exe) ([signature](https://fennel-lang.org/downloads/fennel-0.4.1-windows32.exe.asc))
 
 ## Using Git to download and install Fennel
 


### PR DESCRIPTION
Explain how to install Fennel from the downloads section of the site.

We suggest the non-binary all-in-one script but also provide links to versions that work without Lua installed.

Removed the requirements section since we no longer require Lua, nor Unix, nor git, nor luarocks.