### PR TITLE
implement `with-open` macro

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## ??? / ???
 
+* Add `with-open` macro for auto-closing file handles (#295)
 * Make autogensym symbols omit "#" when appending unique suffix.
 * Fix a bug where autogensyms (using `#`) couldn't be used as multisyms (#294)
 * Add `fennel.searchModule` function to module API

--- a/fennel.lua
+++ b/fennel.lua
@@ -2954,6 +2954,18 @@ Same as ->> except will short-circuit with nil when it encounters a nil value."
          (assert body1 "expected body")
          `(if ,condition
               (do ,body1 ,...)))
+ :let-open (fn [closable-bindings ...]
+              "Like `let`, but invokes (v:close) on every binding after evaluating the body.
+The body is evaluated inside `xpcall` so that bound values will be closed upon
+encountering an error before propagating it."
+              (let [bodyfn    `(fn [] ,...)
+                    closer    `(fn close-handlers# [ok# ...] (if ok# ... (error ... 0)))
+                    traceback `(. (or package.loaded.fennel debug) :traceback)]
+                (for [i 1 (# closable-bindings) 2]
+                  (table.insert closer 4 `(: ,(. closable-bindings i) :close)))
+                `(let ,closable-bindings
+                   ,closer
+                   (close-handlers# (xpcall ,bodyfn ,traceback)))))
  :partial (fn [f ...]
             "Returns a function with all arguments partially applied to f."
             (let [body (list f ...)]

--- a/fennel.lua
+++ b/fennel.lua
@@ -2954,7 +2954,7 @@ Same as ->> except will short-circuit with nil when it encounters a nil value."
          (assert body1 "expected body")
          `(if ,condition
               (do ,body1 ,...)))
- :let-open (fn [closable-bindings ...]
+ :with-open (fn [closable-bindings ...]
               "Like `let`, but invokes (v:close) on every binding after evaluating the body.
 The body is evaluated inside `xpcall` so that bound values will be closed upon
 encountering an error before propagating it."
@@ -2962,9 +2962,10 @@ encountering an error before propagating it."
                     closer    `(fn close-handlers# [ok# ...] (if ok# ... (error ... 0)))
                     traceback `(. (or package.loaded.fennel debug) :traceback)]
                 (for [i 1 (# closable-bindings) 2]
+                  (assert (sym? (. closable-bindings i))
+                    "with-open only allows symbols in bindings")
                   (table.insert closer 4 `(: ,(. closable-bindings i) :close)))
-                `(let ,closable-bindings
-                   ,closer
+                `(let ,closable-bindings ,closer
                    (close-handlers# (xpcall ,bodyfn ,traceback)))))
  :partial (fn [f ...]
             "Returns a function with all arguments partially applied to f."

--- a/reference.md
+++ b/reference.md
@@ -244,6 +244,39 @@ Example:
   (table.concat c ",")) ; => "3,4,5,6"
 ```
 
+### `let-open` bind and auto-close file handles
+
+*(Since ??? TODO: add version before release)*
+
+While Lua will automatically close an open file handle when it's garbage collected,
+GC may not run right away; `let-open` ensures handles are closed immediately, error
+or no, without boilerplate.
+
+The usage is the same as `let`, only every binding should be a file handle or other value
+with a `:close` method. After executing the body, or upon encountering an error, `let-open`
+will invoke `(value:close)` on every bound variable before returning the results.
+
+The body is implicitly wrapped in a function and run with `xpcall` so that all bound
+handles are closed before it re-raises the error.
+
+Example:
+
+```fennel
+; Basic usage
+(let-open [fout (io.open :output.txt :w) fin (io.open :input.txt)]
+  (fout:write "Here is some text!\n")
+  (fin:line)) ; => first line of input.txt
+
+; This demonstrates that the file will also be closed upon error.
+(var fh nil)
+(local (ok err)
+  (pcall #(let-open [file (io.open :test.txt :w)]
+            (set fh file) ; you would normally never do this
+            (error :whoops!))))
+(io.type fh) ; => "closed file"
+[ok err]     ; => [false "<error message and stacktrace>"]
+```
+
 ### `local` declare local
 
 Introduces a new local inside an existing scope. Similar to `let` but

--- a/reference.md
+++ b/reference.md
@@ -244,16 +244,19 @@ Example:
   (table.concat c ",")) ; => "3,4,5,6"
 ```
 
-### `let-open` bind and auto-close file handles
+### `with-open` bind and auto-close file handles
 
 *(Since ??? TODO: add version before release)*
 
 While Lua will automatically close an open file handle when it's garbage collected,
-GC may not run right away; `let-open` ensures handles are closed immediately, error
+GC may not run right away; `with-open` ensures handles are closed immediately, error
 or no, without boilerplate.
 
-The usage is the same as `let`, only every binding should be a file handle or other value
-with a `:close` method. After executing the body, or upon encountering an error, `let-open`
+The usage is similar to `let`, except:
+- destructuring is disallowed (symbols only on the left-hand side)
+- every binding should be a file handle or other value with a `:close` method.
+
+After executing the body, or upon encountering an error, `with-open`
 will invoke `(value:close)` on every bound variable before returning the results.
 
 The body is implicitly wrapped in a function and run with `xpcall` so that all bound
@@ -262,15 +265,15 @@ handles are closed before it re-raises the error.
 Example:
 
 ```fennel
-; Basic usage
-(let-open [fout (io.open :output.txt :w) fin (io.open :input.txt)]
+;; Basic usage
+(with-open [fout (io.open :output.txt :w) fin (io.open :input.txt)]
   (fout:write "Here is some text!\n")
   (fin:line)) ; => first line of input.txt
 
-; This demonstrates that the file will also be closed upon error.
+;; This demonstrates that the file will also be closed upon error.
 (var fh nil)
 (local (ok err)
-  (pcall #(let-open [file (io.open :test.txt :w)]
+  (pcall #(with-open [file (io.open :test.txt :w)]
             (set fh file) ; you would normally never do this
             (error :whoops!))))
 (io.type fh) ; => "closed file"

--- a/test/core.lua
+++ b/test/core.lua
@@ -344,6 +344,13 @@ local function test_macros()
         ["(-?>> :w (. {:w :x}) (. {:x :missing}) (. {:y :z}))"]=nil,
         ["(-?> [:a :b] (table.concat \" \"))"]="a b",
         ["(-?>> \" \" (table.concat [:a :b]))"]="a b",
+        -- let-open should close all handles and return result of body
+        ["(var (fh1 fh2) nil) [(let-open [f1 (io.tmpfile) f2 (io.tmpfile)]\
+          (set [fh1 fh2] [f1 f2]) (f1:write :asdf) (f1:seek :set 0) (f1:read :*a))\
+          (io.type fh1) (io.type fh2)]"]={"asdf", "closed file", "closed file"},
+        -- let-open should propogate errors and still close the file handles
+        ["(var fh nil) (local (ok msg) (pcall #(let-open [f (io.tmpfile)] (set fh f)\
+          (error :bork!)))) [(io.type fh) ok (msg:match :bork!)]"]={"closed file", false, "bork!"},
         -- just a boring old set+fn combo
         ["(require-macros \"test.macros\")\
           (defn1 hui [x y] (global z (+ x y))) (hui 8 4) z"]=12,

--- a/test/core.lua
+++ b/test/core.lua
@@ -344,12 +344,15 @@ local function test_macros()
         ["(-?>> :w (. {:w :x}) (. {:x :missing}) (. {:y :z}))"]=nil,
         ["(-?> [:a :b] (table.concat \" \"))"]="a b",
         ["(-?>> \" \" (table.concat [:a :b]))"]="a b",
-        -- let-open should close all handles and return result of body
-        ["(var (fh1 fh2) nil) [(let-open [f1 (io.tmpfile) f2 (io.tmpfile)]\
+        -- with-open should close all handles and return result of body
+        ["(var (fh1 fh2) nil) [(with-open [f1 (io.tmpfile) f2 (io.tmpfile)]\
           (set [fh1 fh2] [f1 f2]) (f1:write :asdf) (f1:seek :set 0) (f1:read :*a))\
           (io.type fh1) (io.type fh2)]"]={"asdf", "closed file", "closed file"},
-        -- let-open should propogate errors and still close the file handles
-        ["(var fh nil) (local (ok msg) (pcall #(let-open [f (io.tmpfile)] (set fh f)\
+        -- with-open should alow multiple returns
+        ["[(with-open [proc1 (io.popen \"echo hi\") proc2 (io.popen \"echo bye\")]\
+            (values (proc1:read) (proc2:read)))]"] = {'hi', 'bye'},
+        -- with-open should propogate errors and still close the file handles
+        ["(var fh nil) (local (ok msg) (pcall #(with-open [f (io.tmpfile)] (set fh f)\
           (error :bork!)))) [(io.type fh) ok (msg:match :bork!)]"]={"closed file", false, "bork!"},
         -- just a boring old set+fn combo
         ["(require-macros \"test.macros\")\

--- a/test/failures.fnl
+++ b/test/failures.fnl
@@ -73,6 +73,7 @@
   "(macros {:foo {:bar (fn [] `(print :test))}})" "expected each macro to be function"
   "(import-macros test :test.macros) (test.asdf)" "macro not found in imported macro module"
   "(import-macros {: asdf} :test.macros)" "macro asdf not found in module test.macros"
+  "(with-open [(x y z) (values 1 2 3)])" "with-open only allows symbols in bindings"
 })
 
 (fn test-failures []


### PR DESCRIPTION
This introduces a new macro based on clojure's [with-open](https://clojuredocs.org/clojure.core/with-open). Its semantics are the same as `let`, only it expects every binding to be a file handle (or at least something with a `:close` method), and it will automatically invoke `:close` on every binding either after the body has finished or upon encountering an error.

The motivation for this was mainly to reduce the boilerplate of invoking `(file:close)`, with the added benefit that even if there's an error, the file descriptors will *still* be closed immediately instead of whenever the vm gets around to garbage-collecting the file handle's binding.

~~I went with `let-open` for the name because the semantics are so close to that of `let`, which should keep cognitive debt down when it comes to what the semantics are.~~

**Update**: It's now disallowing destructuring, so I've renamed it to `with-open` to get away from implying that the bindings semantics are just like `let`.

### Example

```clojure
(print (with-open [fin (io.open :somefile)]
         (fin:read :*a)))
```
expands to
```clojure
(print
  (let [fin (io.open "somefile")]
    (fn close-handlers_0_ [ok_0_ ...]
      (: fin "close")
      (if ok_0_ ... (error ... 0)))
    (close-handlers_0_ (xpcall (fn [] (fin:read "*a"))
                               (. (or package.loaded.fennel debug) "traceback")))))
```