### PR TITLE
Support native libraries in --compile-binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,15 @@ fennel-bin: launcher.fnl fennel
 # Cross-compile to Windows; very experimental:
 fennel-bin.exe: launcher.fnl fennel lua-5.3.5/src/liblua.a
 	CC=i686-w64-mingw32-gcc fennel --compile-binary $< fennel-bin \
-		lua-5.3.5/src/liblua.a $(LUA_INCLUDE_DIR)
+		lua-5.3.5/src/liblua-mingw.a $(LUA_INCLUDE_DIR)
 
 # Sadly git will not work; you have to get the tarball for a working makefile:
 lua-5.3.5: ; curl https://www.lua.org/ftp/lua-5.3.5.tar.gz | tar xz
 
 # install gcc-mingw-w64-i686
-lua-5.3.5/src/liblua.a: lua-5.3.5
+lua-5.3.5/src/liblua-mingw.a: lua-5.3.5
 	make -C lua-5.3.5 mingw CC=i686-w64-mingw32-gcc
+	mv lua-5.3.5/src/liblua.a $@
 
 ci: luacheck testall count
 

--- a/fennel.lua
+++ b/fennel.lua
@@ -2657,11 +2657,13 @@ end
 
 local function searchModule(modulename, pathstring)
     local pathsepesc = escapepat(pkgConfig.pathsep)
-    local pathsplit = string.format("([^%s]*)%s", pathsepesc, escapepat(pkgConfig.pathsep))
-    modulename = modulename:gsub("%.", pkgConfig.dirsep)
-    for path in string.gmatch((pathstring or module.path)..pkgConfig.pathsep, pathsplit) do
-        local filename = path:gsub(escapepat(pkgConfig.pathmark), modulename)
-        local file = io.open(filename, "rb")
+    local pathsplit = string.format("([^%s]*)%s", pathsepesc,
+                                    escapepat(pkgConfig.pathsep))
+    local nodotModule = modulename:gsub("%.", pkgConfig.dirsep)
+    for path in string.gmatch((pathstring or module.path) .. pkgConfig.pathsep, pathsplit) do
+        local filename = path:gsub(escapepat(pkgConfig.pathmark), nodotModule)
+        local filename2 = path:gsub(escapepat(pkgConfig.pathmark), modulename)
+        local file = io.open(filename) or io.open(filename2)
         if(file) then
             file:close()
             return filename

--- a/fennelbinary.fnl
+++ b/fennelbinary.fnl
@@ -251,7 +251,7 @@ int main(int argc, char *argv[]) {
 (local help (: "
 Usage: %s --compile-binary FILE OUT STATIC_LUA_LIB LUA_INCLUDE_DIR
 
-Compile a binary from your Fennel program. This functionality is very
+Compile a binary from your Fennel program. This functionality is VERY
 experimental and subject to change in future versions!
 
 Requires a C compiler, a copy of liblua, and Lua's dev headers. Implies
@@ -274,9 +274,10 @@ used (default: cc) or set CC_OPTS to pass in compiler options. For example
 set CC_OPTS=-static to generate a binary with static linking.
 
 To include C libraries that contain Lua modules, add --native-module path/to.so,
-and to include C libraries without modules, use --native-librari path/to.so.
+and to include C libraries without modules, use --native-library path/to.so.
+These options are unstable, barely tested, and even more likely to break.
 
-This method is currently limited to programs do not transitively requiring Lua
+This method is currently limited to programs do not transitively require Lua
 modules. Requiring a Lua module directly will work, but requiring a Lua module
 which requires another will fail." :format (. arg 0) (. arg 0)))
 

--- a/fennelbinary.fnl
+++ b/fennelbinary.fnl
@@ -167,7 +167,10 @@ int main(int argc, char *argv[]) {
         (table.insert out (: "  int luaopen_%s(lua_State *L);" :format open))
         (table.insert out (: "  lua_pushcfunction(L, luaopen_%s);" :format open))
         (table.insert out (: "  lua_setfield(L, -2, \"%s\");\n"
-                             :format (open:gsub "_" ".")))))
+                             ;; changing initial underscore breaks luaossl
+                             :format (.. (open:sub 1 1)
+                                         (-> (open:sub 2)
+                                             (: :gsub "_" ".")))))))
     (table.concat out "\n")))
 
 (fn fennel->c [filename native options]
@@ -214,7 +217,8 @@ int main(int argc, char *argv[]) {
     (when (not (execute (table.concat compile-command " ")))
       (print :failed: (table.concat compile-command " "))
       (os.exit 1))
-    (os.remove lua-c-path)
+    (when (not (os.getenv "FENNEL_DEBUG"))
+      (os.remove lua-c-path))
     (os.exit 0)))
 
 (fn native-path? [path]


### PR DESCRIPTION
After trying unsuccessfully to create binaries which can make HTTPS requests (https://git.sr.ht/~technomancy/fennel-luasocket-example) I made some changes which allow native code to be used with the `--compile-binary` command.

Even though I was unable to get this working with any existing HTTPS clients for Lua, it could still be useful for other more well-behaved C libraries. It does work for `luasocket` in the unlikely case that you need sockets that don't have TLS.

The change to `fennel.lua` was made in order to support the edge case of modules which have not replaced the `.` in the module name with `/` as you're supposed to do. Lua is tolerant of this weird behavior, so I figured we probably should be to and not fail on modules that have dots in the actual filenames.

The `native-loader` function is based on [similar functionality in luastatic](https://github.com/ers35/luastatic/blob/master/luastatic.lua#L391)