### PR TITLE
Fix dev rockspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 LUA ?= lua
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+LUADIR ?= $(PREFIX)/share/lua/$(LUA_VERSION)
+
+build: fennel
 
 test: fennel
 	$(LUA) test/init.lua
@@ -65,4 +70,10 @@ coverage: fennel
 	@echo "generated luacov.report.out"
 	@echo "Note: 'built-ins' coverage is inaccurate because it isn't a real file."
 
-.PHONY: test testall luacheck count ci clean coverage
+install: fennel fennel.lua fennelview.lua
+	mkdir -p $(BINDIR) && \
+		cp fennel $(BINDIR)/
+	mkdir -p $(LUADIR) && \
+		for f in fennel.lua fennelview.lua; do cp $$f $(LUADIR)/; done
+
+.PHONY: build test testall luacheck count ci clean coverage install

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 LUA ?= lua
+LUA_VERSION ?= $(shell $(LUA) -e 'v=_VERSION:gsub("^Lua *","");print(v)')
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 LUADIR ?= $(PREFIX)/share/lua/$(LUA_VERSION)

--- a/rockspecs/fennel-scm-2.rockspec
+++ b/rockspecs/fennel-scm-2.rockspec
@@ -15,14 +15,15 @@ dependencies = {
    "lua >= 5.1"
 }
 build = {
-   type = "builtin",
-   modules = {
-       fennel = "fennel.lua",
-       fennelview = "fennelview.fnl.lua",
+   type = "make",
+   build_variables = {
+       -- Warning: variable CFLAGS was not passed in build_variables
+       CFLAGS = "$(CFLAGS)",
+       LUA = "$(LUA)",
    },
-   install = {
-       bin = {
-           "fennel"
-       }
-   }
+   install_variables = {
+       PREFIX = "$(PREFIX)",
+       BINDIR = "$(BINDIR)",
+       LUADIR = "$(LUADIR)",
+   },
 }


### PR DESCRIPTION
I am attempting to install the development version of Fennel using luarocks but the rockspec file `fennel-scm-2.rockspec` looks like broken:
```
[nix-shell]% luarocks --local make

cp: cannot stat 'fennelview.fnl.lua': No such file or directory

Error: Build error: Failed installing fennelview.fnl.lua in /home/mnacamura/.luarocks/lib/luarocks/rocks-5.2/fennel/scm-2/lua/fennelview.lua: Failed copying fennelview.fnl.lua to /home/mnacamura/.luarocks/lib/luarocks/rocks-5.2/fennel/scm-2/lua/fennelview.lua
```
This PR may fix it:
```
[nix-shell]% luarocks --local make

echo "#!/usr/bin/env /nix/store/q4jxjzw326xvp8p0v0l7r3zf4g8ydmp3-lua-5.2.4/bin/lua" > fennel
/nix/store/q4jxjzw326xvp8p0v0l7r3zf4g8ydmp3-lua-5.2.4/bin/lua old_launcher.lua --globals "" --require-as-include --metadata --compile launcher.fnl >> fennel
chmod 755 fennel
mkdir -p /home/mnacamura/.luarocks/lib/luarocks/rocks-5.2/fennel/scm-2/bin && \
	cp fennel /home/mnacamura/.luarocks/lib/luarocks/rocks-5.2/fennel/scm-2/bin/
mkdir -p /home/mnacamura/.luarocks/lib/luarocks/rocks-5.2/fennel/scm-2/lua && \
	for f in fennel.lua fennelview.lua; do cp $f /home/mnacamura/.luarocks/lib/luarocks/rocks-5.2/fennel/scm-2/lua/; done
fennel scm-2 is now installed in /home/mnacamura/.luarocks (license: MIT)
```
