### PR TITLE
add Lua 5.4 tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,13 @@ orbs:
 jobs:
   build:
     docker:
-      - image: debian:buster-slim
+      - image: debian:testing
     steps:
       - checkout
-      - run: apt-get update -qq && apt-get install -qq cloc make lua-check luajit lua5.1 lua5.2 lua5.3
+      - run:
+          command: |
+            apt-get update -qq && apt-get install -qq cloc make lua-check \
+              luajit lua5.1 lua5.2 lua5.3 lua5.4
       - run: make ci
   windows:
     executor: windows/default

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ testall: fennel
 	@printf 'Testing lua 5.1:\n'  ; lua5.1 test/init.lua
 	@printf "\nTesting lua 5.2:\n"; lua5.2 test/init.lua
 	@printf "\nTesting lua 5.3:\n"; lua5.3 test/init.lua
+	@printf "\nTesting lua 5.4:\n"; lua5.4 test/init.lua
 	@printf "\nTesting luajit:\n" ; luajit test/init.lua
 
 luacheck:


### PR DESCRIPTION
I noticed that Lua 5.4 had hit Debian Testing, so I tried changing our build job to use the `debian:testing` docker image and added lua5.4 to the tests. Works!

Did this as a PR mainly to give @technomancy veto power over making the change from `debian:buster-slim` to `debian:testing`.