### PR TITLE
add --lua flag to launcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build: fennel
 test: fennel.lua fennel
 	$(LUA) test/init.lua
 
+testall: export FNL_TESTALL = 1
 testall: export FNL_TEST_OUTPUT ?= text
 testall: fennel
 	@printf 'Testing lua 5.1:\n'  ; lua5.1 test/init.lua

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Fix a bug where method calls would early-evaluate their receiver.
 * Fix a bug where multi-arity comparisons would early-evaluate their arguments.
+* Add `--lua` CLI flag for specifying a custom Lua command/executable. (#324)
 
 ## 0.5.0 / 2020-08-08
 

--- a/src/launcher.fnl
+++ b/src/launcher.fnl
@@ -21,6 +21,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --no-metadata           : Disable function metadata, even in REPL
   --correlate             : Make Lua output line numbers match Fennel input
   --load FILE (-l)        : Load the specified FILE before executing the command
+  --lua LUA_EXE           : Run in a child process with LUA_EXE (experimental)
   --no-fennelrc           : Skip loading ~/.fennelrc when launching repl
   --compile-binary FILE
       OUT LUA_LIB LUA_DIR : Compile FILE to standalone binary OUT (experimental)
@@ -57,8 +58,18 @@ Run fennel, a lisp programming language for the Lua runtime.
     (dosafely fennel.dofile file options)
     (table.remove arg i)))
 
+(fn handle-lua [i]
+  (table.remove arg i) ; remove the --lua flag from args
+  (let [tgt-lua (table.remove arg i)
+        cmd [(string.format "%s %s" tgt-lua (. arg 0))]]
+    (for [i 1 (# arg)] ; quote args to prevent shell escapes when executing
+      (table.insert cmd (string.format "%q" (. arg i))))
+    (let [ok (os.execute (table.concat cmd " "))]
+      (os.exit (if ok 0 1) true))))
+
 (for [i (# arg) 1 -1]
   (match (. arg i)
+    "--lua" (handle-lua i)
     "--no-searcher" (do (set options.no_searcher true)
                         (table.remove arg i))
     "--indent" (do (set options.indent (table.remove arg (+ i 1)))

--- a/src/launcher.fnl
+++ b/src/launcher.fnl
@@ -67,9 +67,12 @@ Run fennel, a lisp programming language for the Lua runtime.
     (let [ok (os.execute (table.concat cmd " "))]
       (os.exit (if ok 0 1) true))))
 
+;; check for --lua first to ensure its child process retains all flags
+(for [i (# arg) 1 -1]
+  (match (. arg i) "--lua" (handle-lua i)))
+
 (for [i (# arg) 1 -1]
   (match (. arg i)
-    "--lua" (handle-lua i)
     "--no-searcher" (do (set options.no_searcher true)
                         (table.remove arg i))
     "--indent" (do (set options.indent (table.remove arg (+ i 1)))

--- a/test/cli.fnl
+++ b/test/cli.fnl
@@ -3,16 +3,45 @@
 ;; These are the slowest tests, so for now we just have a basic sanity check
 ;; to ensure that it compiles and can evaluate math.
 
+(local *testall* (os.getenv :FNL_TESTALL)) ; set by `make testall`
+
 (fn file-exists? [filename]
   (let [f (io.open filename)]
-    (if f
-        (do (f:close) true)
-        false)))
+    (when f (f:close) true)))
+
+(λ peval [code ...]
+  (local cmd [(string.format "./fennel --eval %q" code) ...])
+  (let [proc (io.popen (table.concat cmd " "))
+        output (: (proc:read :*a) :gsub "\n$" "")]
+    (values (proc:close) output))) ; proc:close gives exit status
 
 (fn test-cli []
   ;; skip this if we haven't compiled the CLI
-  (when (file-exists? "fennel")
-    (l.assertEquals "6\n" (: (io.popen "./fennel --eval \"(+ 1 2 3)\"")
-                             :read :*a))))
+  (when (file-exists? "./fennel")
+    (l.assertEquals [(peval "(+ 1 2 3)")] [true "6"])))
 
-{: test-cli}
+(fn test-lua-flag []
+  ;; skip this when cli is not compiled or not running tests with `make testall`
+  (when (and *testall* (file-exists? :./fennel))
+    (let [;; running io.popen for all 20 combinations of lua versions is slow,
+          ;; so we'll just pick the next one in the list after host-lua
+          host-lua (match _VERSION
+                          "Lua 5.1" (if _G.jit :luajit :lua5.1)
+                          (.. :lua (_VERSION:sub 5)))
+          lua-exec ((fn pick-lua [lua-vs i lua-v]
+                      (if (= host-lua lua-v)
+                        (. lua-vs (+ 1 (% i (# lua-vs)))) ; circular next
+                        (pick-lua lua-vs (next lua-vs i))))
+                    [:lua5.1 :lua5.2 :lua5.3 :lua5.4 :luajit])
+          run #(pick-values 2 (peval $ (: "--lua %q" :format lua-exec)))]
+      (l.assertEquals [(run "(match (_VERSION:sub 5)
+                              :5.1 (if _G.jit :luajit :lua5.1)
+                              v-num (.. :lua v-num))")]
+                      [true lua-exec]
+                      (.. "should execute code in Lua runtime: " lua-exec))
+      (l.assertEquals
+        [(run "(print :test) (os.exit 1 true)")]
+        ;; pcall in Lua 5.1 doesn't give status with (proc:close)
+        {1 (if (= _VERSION "Lua 5.1") true nil) 2 "test"}
+        (.. "errors should cause failing exit status with --lua " lua-exec)))))
+{: test-cli : test-lua-flag}


### PR DESCRIPTION
This introduces a new flag that re-executes the given CLI command with the provided options in a child process using the supplied Lua executable via `os.execute`. It allows CLI users to run the launcher in an arbitrary lua VM without resorting to such shellisms as `luaX.Y $(which fennel)`, decoupling the launcher from its host runtime.

For example,
```shell
fennel --lua luajit -e '_VERSION'
```
will invoke the equivalent of
```shell
luajit path/to/fennel -e '_VERSION'`
```
## Flag name

I'd be open to being more explicit with `--lua-version`, but I kind of like the brevity of `--lua`. I don't feel strongly either way, so I figured I'd mention it before we make it legacy.

## Tests

The tests for this flag only run under `make testall`, since that's the only time we can safely assume the host environment has every lua version available.

Initially, I was letting the test suite for every lua version run the `--lua` test for every *other* version, giving us a total of 20 `io.popen` invocations, which in turn invoke `os.execute`, but this led to a rather significant slowdown.

Instead, I have each test for a given Lua executable simply test the flag for the next Lua executable in the list. It does add some complex logic, and there's still some slowdown (about half a second on my machine), but that's better than quadrupling the delay.