### PR TITLE
Test that pattern matches before destructuring

### DIFF
--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -332,11 +332,10 @@ introduce for the duration of the body if it does match."
         (and (list? pattern) (= (. pattern 2) `?))
         (let [(pcondition bindings) (match-pattern vals (. pattern 1)
                                                    unifications)
-              condition `(and ,pcondition)]
-          (for [i 3 (length pattern)] ; splice in guard clauses
-            (table.insert condition (. pattern i)))
-          (values `(let ,bindings
-                     ,condition) bindings))
+              condition `(and ,(unpack pattern 3))]
+          (values `(and ,pcondition
+                        (let ,bindings
+                          ,condition)) bindings))
         ;; multi-valued patterns (represented as lists)
         (list? pattern)
         (match-values vals pattern unifications match-pattern)

--- a/test/macro.fnl
+++ b/test/macro.fnl
@@ -193,6 +193,13 @@
                   [[1 2] [3 4]] :nope10
                   nil :success
                   :nope11)" :success
+               ;; nil matching with where
+               "(match nil
+                  (where (1 2 3 4) true) :nope1
+                  (where {:a 1 :b 2} true) :nope2
+                  (where [a b c d] (= 100 (* a b c d))) :nope3
+                  ([a b c d] ? (= 100 (* a b c d))) :nope4
+                  :success)" :success
                ;; no match
                "(match [1 2 3 4]
                   (1 2 3 4) :nope1


### PR DESCRIPTION
This patch fixes a bug where the `where` clause in `match` binds values (including destructuring table patterns) before testing that the pattern actually matches.

Without this patch, the included test errors.

A minimal example:

```clj
>> (match nil [x y z] :table _ :not-a-table)
"not-a-table"

>> (match nil (where [x y z] (not= nil x)) :table _ :not-a-table)
runtime error: attempt to index local '_0_0' (a nil value)
```