### PR TITLE
Fix match multi-value destructuring with guards

### DIFF
--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -364,10 +364,13 @@ introduce for the duration of the body if it does match."
   "How many multi-valued clauses are there? return a list of that many gensyms."
   (let [syms (list (gensym))]
     (for [i 1 (length clauses) 2]
-      (if (list? (. clauses i))
-          (each [valnum (ipairs (. clauses i))]
-            (if (not (. syms valnum))
-                (tset syms valnum (gensym))))))
+      (let [clause (if (and (list? (. clauses i)) (= `? (. clauses i 2)))
+                       (. clauses i 1)
+                       (. clauses i))]
+        (if (list? clause)
+            (each [valnum (ipairs clause)]
+              (if (not (. syms valnum))
+                  (tset syms valnum (gensym)))))))
     syms))
 
 (fn match* [val ...]

--- a/test/macro.fnl
+++ b/test/macro.fnl
@@ -200,6 +200,10 @@
                   (where [a b c d] (= 100 (* a b c d))) :nope3
                   ([a b c d] ? (= 100 (* a b c d))) :nope4
                   :success)" :success
+               ;; destructure multiple values with where
+               "(match (values 1 2 3 4 :ok)
+                  (where (a b c d e) (= 1 a)) e
+                  _ :not-ok)" :ok
                ;; old tests adopted to new syntax
                "(match [{:sieze :him} 5]
                   (where [f 4] f.sieze (= f.sieze :him)) 4


### PR DESCRIPTION
I noticed while debugging #346 that `match` was always binding at least 3 values when I used a `where` clause, because there are usually 3 elements in the `(where ...)` list. This patch changes the multi-value calculation so that it checks the actual values being destructured, even when nested in a `where` clause.

```clj
;; before
>> (macrodebug (match (values 1 2 3 4 5) (where (a b c d e) (= 1 a)) a))
(let [(_0_ _1_ _2_) (values 1 2 3 4)] ; <- missing _3_ and _4_
  (if ... match clauses ...))

;; after
>> (macrodebug (match (values 1 2 3 4 5) (where (a b c d e) (= 1 a)) a))
(let [(_0_ _1_ _2_ _3_ _4_) (values 1 2 3 4 5)]
  (if ... match clauses ...))