### PR TITLE
Fix destructuring kv tables inside values

### DIFF
--- a/src/fennel/compiler.fnl
+++ b/src/fennel/compiler.fnl
@@ -722,7 +722,8 @@ which we have to do if we don't know."
         (compile-top-target left-names)
         (when declaration
           (each [_ sym (ipairs left)]
-            (tset scope.symmeta (utils.deref sym) {:var isvar})))
+            (when (utils.sym? sym)
+              (tset scope.symmeta (utils.deref sym) {:var isvar}))))
         ;; recurse if left-side tables found
         (each [_ pair (utils.stablepairs tables)]
           (destructure1 (. pair 1) [(. pair 2)] left))))

--- a/test/core.fnl
+++ b/test/core.fnl
@@ -202,7 +202,8 @@
                "(local [a b c &as t] [1 2 3]) (+ c (. t 2))" 5
                "(local (-a -b) ((fn [] (values 4 29)))) (+ -a -b)" 33
                "(var [a [b c]] [1 [2 3]]) (set a 2) (set c 8) (+ a b c)" 12
-               "(var x 0) (each [_ [a b] (ipairs [[1 2] [3 4]])] (set x (+ x (* a b)))) x" 14}]
+               "(var x 0) (each [_ [a b] (ipairs [[1 2] [3 4]])] (set x (+ x (* a b)))) x" 14
+               "(let [({: x} y) (values {:x 10} 20)] (+ x y))" 30}]
     (each [code expected (pairs cases)]
       (l.assertEquals (fennel.eval code {:correlate true}) expected code))))
 


### PR DESCRIPTION
(I'm very much not familiar with the compiler, but I at least tracked the error down to this line, and tests pass, so I figure there's a decent chance this is the right fix)

When symmeta is added in destructure-values, we have to check that the
value is in fact a sym (not a table). Any names declared in the table
destructure have their symmeta added in the recursive call to
destructure1.

This manifests as a compiler error:

    (let [({:x 10}) {:x 10}] x) => Error: table index is nil

... from setting a table key to (utils.deref {:x 10}), which is nil.

Though note that sequential table destructuring accidentally worked,
since utils.deref is just (. sym 1), or in this case, `x`:

    (let [([x]) [10]] x) => 10

This appears to be a regression from b43fe48.