### PR TITLE
Add accumulation macro and its tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Backwards-incompatible changes are **marked in bold**.
 * Make macro tables shadow runtime tables more consistently
 * Add `,complete foo` repl command
 * Add `fennel.syntax` function describing built-ins
+* Add `accumulate` macro
 
 ## 0.9.2 / 2021-05-02
 

--- a/reference.md
+++ b/reference.md
@@ -812,6 +812,28 @@ value into a table is a no-op.
 Like `each` and `for`, the table comprehensions support an `:until`
 clause for early termination.
 
+### `accumulate` iterator accumulation
+
+Run through an iterator and performs accumulation, similar to `fold`
+and `reduce` commonly used in functional programming languages.
+Like `collect` and `icollect`, it takes an iterator binding table
+and an expression as its arguments. The difference is that in
+`accumulate`, the first two items in the binding table are used as
+an "accumulator" variable and its initial value.
+For each iteration step, it evaluates the given expression and
+the returned value becomes the next accumulator variable.
+`accumulate` returns the final value of the accumulator variable.
+
+Example:
+
+```fennel
+(accumulate [avg 0
+             i n (ipairs [1 2 3 4])]
+  (let [/i (/ i)]
+    (+ (* avg (- 1 /i)) (* n /i))))
+;; -> 2.5
+```
+
 ### `values` multi-valued return
 
 Returns multiple values from a function. Usually used to signal

--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -149,7 +149,7 @@ returns
        (tset tbl# (+ (length tbl#) 1) ,value-expr))
      tbl#))
 
-(fn accum* [iter-tbl accum-expr ...]
+(fn accumulate* [iter-tbl accum-expr ...]
   "Accumulation macro.
 Similar to `collect` and `icollect`, it takes a binding table and an
 expression as its arguments.
@@ -161,8 +161,8 @@ evaluated, and its returned value updates the accumulating variable.
 It eventually returns the final value of the accumulating variable.
 
 For example,
-  (accum [total 0
-          _ n (pairs {:apple 2 :orange 3})]
+  (accumulate [total 0
+               _ n (pairs {:apple 2 :orange 3})]
     (+ total n))
 returns
   5"
@@ -491,7 +491,7 @@ Syntax:
  :with-open with-open*
  :collect collect*
  :icollect icollect*
- :accum accum*
+ :accumulate accumulate*
  :partial partial*
  :lambda lambda*
  :pick-args pick-args*

--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -149,7 +149,7 @@ returns
        (tset tbl# (+ (length tbl#) 1) ,value-expr))
      tbl#))
 
-(fn accumulate* [iter-tbl accum-expr ...]
+(fn accum* [iter-tbl accum-expr ...]
   "Accumulation macro.
 Similar to `collect` and `icollect`, it takes a binding table and an
 expression as its arguments.
@@ -161,8 +161,8 @@ evaluated, and its returned value updates the accumulating variable.
 It eventually returns the final value of the accumulating variable.
 
 For example,
-  (accumulate [total 0
-               _ n (pairs {:apple 2 :orange 3})]
+  (accum [total 0
+          _ n (pairs {:apple 2 :orange 3})]
     (+ total n))
 returns
   5"
@@ -491,7 +491,7 @@ Syntax:
  :with-open with-open*
  :collect collect*
  :icollect icollect*
- :accumulate accumulate*
+ :accum accum*
  :partial partial*
  :lambda lambda*
  :pick-args pick-args*

--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -151,14 +151,13 @@ returns
 
 (fn accumulate* [iter-tbl accum-expr ...]
   "Accumulation macro.
-Similar to `collect` and `icollect`, it takes a binding table and an
-expression as its arguments.
+It takes a binding table and an expression as its arguments.
 In the binding table, the first symbol is bound to the second value, being an
-initial accumulating variable. The rest are an iterator binding table in the
+initial accumulator variable. The rest are an iterator binding table in the
 format `each` takes.
 It runs through the iterator in each step of which the given expression is
-evaluated, and its returned value updates the accumulating variable.
-It eventually returns the final value of the accumulating variable.
+evaluated, and its returned value updates the accumulator variable.
+It eventually returns the final value of the accumulator variable.
 
 For example,
   (accumulate [total 0

--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -149,6 +149,35 @@ returns
        (tset tbl# (+ (length tbl#) 1) ,value-expr))
      tbl#))
 
+(fn accumulate* [iter-tbl accum-expr ...]
+  "Accumulation macro.
+Similar to `collect` and `icollect`, it takes a binding table and an
+expression as its arguments.
+In the binding table, the first symbol is bound to the second value, being an
+initial accumulating variable. The rest are an iterator binding table in the
+format `each` takes.
+It runs through the iterator in each step of which the given expression is
+evaluated, and its returned value updates the accumulating variable.
+It eventually returns the final value of the accumulating variable.
+
+For example,
+  (accumulate [total 0
+               _ n (pairs {:apple 2 :orange 3})]
+    (+ total n))
+returns
+  5"
+  (assert (and (sequence? iter-tbl) (>= (length iter-tbl) 4))
+          "expected initial value and iterator binding table")
+  (assert (not= nil accum-expr) "expected accumulating expression")
+  (assert (= nil ...)
+          "expected exactly one body expression. Wrap multiple expressions with do")
+  (let [accum-var (table.remove iter-tbl 1)
+        accum-init (table.remove iter-tbl 1)]
+    `(do (var ,accum-var ,accum-init)
+         (each ,iter-tbl
+           (set ,accum-var ,accum-expr))
+         ,accum-var)))
+
 (fn partial* [f ...]
   "Returns a function with all arguments partially applied to f."
   (assert f "expected a function to partially apply")
@@ -462,6 +491,7 @@ Syntax:
  :with-open with-open*
  :collect collect*
  :icollect icollect*
+ :accumulate accumulate*
  :partial partial*
  :lambda lambda*
  :pick-args pick-args*

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -35,6 +35,16 @@
          (tonumber num))"
       [24 58 1999]))
 
+(fn test-accumulate []
+  (== "(accumulate [n 0
+                    _ _ (pairs {:one 1 :two nil :three 3})]
+         (+ n 1))"
+      2)
+  (== "(accumulate [yes? true
+                    _ s (ipairs [:yes :no :yes])]
+         (and yes? (string.match s :yes)))"
+      nil))
+
 (fn test-conditions []
   (== "(var x 0) (for [i 1 10 :until (= i 5)] (set x i)) x" 4)
   (== "(var x 0) (each [_ i (ipairs [1 2 3]) :until (< 2 x)] (set x i)) x" 3)
@@ -44,4 +54,5 @@
 {: test-each
  : test-for
  : test-comprehensions
+ : test-accumulate
  : test-conditions}

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -35,13 +35,13 @@
          (tonumber num))"
       [24 58 1999]))
 
-(fn test-accumulate []
-  (== "(accumulate [n 0
-                    _ _ (pairs {:one 1 :two nil :three 3})]
+(fn test-accum []
+  (== "(accum [n 0
+               _ _ (pairs {:one 1 :two nil :three 3})]
          (+ n 1))"
       2)
-  (== "(accumulate [yes? true
-                    _ s (ipairs [:yes :no :yes])]
+  (== "(accum [yes? true
+               _ s (ipairs [:yes :no :yes])]
          (and yes? (string.match s :yes)))"
       nil))
 
@@ -54,5 +54,5 @@
 {: test-each
  : test-for
  : test-comprehensions
- : test-accumulate
+ : test-accum
  : test-conditions}

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -35,24 +35,24 @@
          (tonumber num))"
       [24 58 1999]))
 
-(fn test-accum []
+(fn test-accumulate []
   (== "(var x true)
-       (let [y (accum [state :init
-                       _ _ (pairs {})]
+       (let [y (accumulate [state :init
+                            _ _ (pairs {})]
                  (do (set x false)
                      :update))]
          [x y])"
       [true :init])
-  (== "(accum [s :fen
-               _ c (ipairs [:n :e :l :o]) :until (>= c :o)]
+  (== "(accumulate [s :fen
+                    _ c (ipairs [:n :e :l :o]) :until (>= c :o)]
          (.. s c))"
       "fennel")
-  (== "(accum [n 0
-               _ _ (pairs {:one 1 :two nil :three 3})]
+  (== "(accumulate [n 0
+                    _ _ (pairs {:one 1 :two nil :three 3})]
          (+ n 1))"
       2)
-  (== "(accum [yes? true
-               _ s (ipairs [:yes :no :yes])]
+  (== "(accumulate [yes? true
+                    _ s (ipairs [:yes :no :yes])]
          (and yes? (string.match s :yes)))"
       nil))
 
@@ -65,5 +65,5 @@
 {: test-each
  : test-for
  : test-comprehensions
- : test-accum
+ : test-accumulate
  : test-conditions}

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -36,6 +36,17 @@
       [24 58 1999]))
 
 (fn test-accum []
+  (== "(var x true)
+       (let [y (accum [state :init
+                       _ _ (pairs {})]
+                 (do (set x false)
+                     :update))]
+         [x y])"
+      [true :init])
+  (== "(accum [s :fen
+               _ c (ipairs [:n :e :l :o]) :until (>= c :o)]
+         (.. s c))"
+      "fennel")
   (== "(accum [n 0
                _ _ (pairs {:one 1 :two nil :three 3})]
          (+ n 1))"


### PR DESCRIPTION
Close #367.

Following @technomancy's advice (thanks!), I fixed the macro to not skip `nil` in each accumulation step.

Because `reduce` and `fold` are frequently used in third-party libraries, I named it `accumulate`.
I'm still unsure about the name though. `accumulate` might be too long to type so its shorthand `accum` or `reduce` or `fold` could be better. Anyway suggestions are welcome.