### PR TITLE
Add :preprocess option to fennel.view

### DIFF
--- a/src/fennel/view.fnl
+++ b/src/fennel/view.fnl
@@ -255,6 +255,7 @@ as numeric escapes rather than letter-based escapes, which is ugly."
           ;; main serialization loop, entry point is defined below
           (let [indent (or indent 0)
                 options (or options (make-options x))
+                x (if options.preprocess (options.preprocess x options) x)
                 tv (type x)]
             (if (or (= tv :table)
                     (and (= tv :userdata)
@@ -290,6 +291,9 @@ Can take an options table with these keys:
   lengths
 * :max-sparse-gap (integer, default 10) maximum gap to fill in with nils in
   sparse sequential tables.
+* :preprocess (function) if present, called on x (and recursively on each value
+  in x), and the result is used for pretty printing; takes the same arguments as
+  `fennel.view`
 
 The `__fennelview` metamethod should take the table being serialized as its
 first argument, a function as its second argument, options table as third
@@ -375,5 +379,10 @@ results regardless of nesting:
 
 Note that even though we've only indented inner elements of our table
 with 10 spaces, the result is correctly indented in terms of outer
-table, and inner tables also remain indented correctly."
+table, and inner tables also remain indented correctly.
+
+When using the `:preprocess` option, avoid modifying any tables in-place in the
+passed function. Since Lua tables are mutable and provided to `:preprocess`
+without copying, any modification done in `:preprocess` will be visible outside
+of `fennel.view`."
   (pp x (make-options x options) 0))

--- a/test/core.fnl
+++ b/test/core.fnl
@@ -417,7 +417,14 @@
                               (fennel.view styles {:prefer-colon? true})
                               (fennel.view styles {:prefer-colon? false})]
                              {:one-line? true})"
-               "[\":colon \\\"quote\\\" \\\"depends\\\"\" \":colon \\\"quote\\\" :depends\" \":colon \\\"quote\\\" \\\"depends\\\"\"]"}]
+               "[\":colon \\\"quote\\\" \\\"depends\\\"\" \":colon \\\"quote\\\" :depends\" \":colon \\\"quote\\\" \\\"depends\\\"\"]"
+               ;; :preprocess
+               "((require :fennel.view) [1 2 3] {:preprocess (fn [x] x)})"
+               "[1 2 3]"
+               "((require :fennel.view) [1 2 3] {:preprocess (fn [x] (if (= (type x) :number) (+ x 1) x))})"
+               "[2 3 4]"
+               "((require :fennel.view) [[] [1] {:x [] [] [2]}] {:preprocess (fn [x] (if (and (= (type x) :table) (= (next x) nil)) :empty-table x))})"
+               "[\"empty-table\" [1] {:x \"empty-table\" :empty-table [2]}]"}]
     (each [code expected (pairs cases)]
       (l.assertEquals (fennel.eval code {:correlate true :compiler-env _G})
                       expected code))


### PR DESCRIPTION
It allows for pretty-printing of any userdata with custom type.
E.g. in Awesome WM a key object has `type(obj) = "key"`.

Fixes #356