### PR TITLE
Fix lua special and add test case

### DIFF
--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -295,9 +295,9 @@ and lacking args will be nil, use lambda for arity-checked functions." true)
 (fn SPECIALS.lua [ast _ parent]
   (compiler.assert (or (= (length ast) 2) (= (length ast) 3))
                    "expected 1 or 2 arguments" ast)
-  (when (not= (. ast 2) nil)
+  (when (not= :nil (-?> (utils.sym? (. ast 2)) utils.deref))
     (table.insert parent {: ast :leaf (tostring (. ast 2))}))
-  (when (not= (. ast 3) nil)
+  (when (not= :nil (-?> (utils.sym? (. ast 3)) utils.deref))
     (tostring (. ast 3))))
 
 (fn SPECIALS.doc [ast scope parent]

--- a/test/core.fnl
+++ b/test/core.fnl
@@ -227,7 +227,8 @@
                    "(xyz (if (and c1 c2) true false) 52))") 52
                "(let [t {} _ (set t.field :let-side)] t.field)" :let-side
                "(local a_0_ (or (getmetatable {}) {:b-c {}}))
-                (tset (. a_0_ :b-c) :d 12) (. a_0_ :b-c :d)" 12}]
+                (tset (. a_0_ :b-c) :d 12) (. a_0_ :b-c :d)" 12
+               "(local x (lua \"y = 4\" \"6\")) (* _G.y x)" 24}]
     (each [code expected (pairs cases)]
       (l.assertEquals (fennel.eval code {:correlate true}) expected code))))
 


### PR DESCRIPTION
The lua special function doesn't produce what the website, or comments say it should.

This statement:
```
(each [_ v (ipairs (lua nil "{1,2,3}"))]
  (print v))
```

should print the contents of the table, but results in the following lua:
```
nil
for _, v in ipairs({1,2,3}) do
  print(v)
end
return nil
```

and the following lua runtime error: `unexpected symbol near 'nil'`.

Since the lua special doesn't compile its arguments, comparing to `nil` always results in false because it's comparing to the result from the parser, not the nil literal the compiler would output. Checking if the argument is a symbol, dereferencing it if it is, and comparing it to `:nil` instead of `nil` works correctly.