### PR TITLE
Relax (i)collect :into clause rules

### DIFF
--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -115,7 +115,11 @@ encountering an error before propagating it."
         (do (assert (not into) "expected only one :into clause")
             (set into (table.remove iter-tbl (+ i 1)))
             (table.remove iter-tbl i))))
-  (assert (or (not into) (table? into)) "expected table in :into clause")
+  (assert (or (not into)
+              (sym? into)
+              (table? into)
+              (list? into))
+          "expected table, function call, or symbol in :into clause")
   (or into []))
 
 (fn collect* [iter-tbl key-value-expr ...]

--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -112,7 +112,8 @@ encountering an error before propagating it."
   (var into nil)
   (for [i (length iter-tbl) 1 -1]
     (if (= :into (. iter-tbl i))
-        (do (set into (table.remove iter-tbl (+ i 1)))
+        (do (assert (not into) "expected only one :into clause")
+            (set into (table.remove iter-tbl (+ i 1)))
             (table.remove iter-tbl i))))
   (assert (or (not into) (table? into)) "expected table in :into clause")
   (or into []))

--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -110,7 +110,7 @@ encountering an error before propagating it."
 
 (fn into-val [iter-tbl]
   (var into nil)
-  (for [i (length iter-tbl) 2 -1]
+  (for [i (length iter-tbl) 1 -1]
     (if (= :into (. iter-tbl i))
         (do (set into (table.remove iter-tbl (+ i 1)))
             (table.remove iter-tbl i))))

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -40,7 +40,10 @@
   (== "(icollect [_ x (ipairs [2 3]) :into [11]] (* x 11))"
       [11 22 33])
   (== "(icollect [:into [11] _ x (ipairs [2 3])] (* x 11))"
-      [11 22 33]))
+      [11 22 33])
+  (let [(ok? msg) (pcall fennel.compileString "(icollect [:into [] _ x (ipairs [2 3]) :into []] x)")]
+    (l.assertFalse ok?)
+    (l.assertStrContains msg ":into clause")))
 
 (fn test-accumulate []
   (== "(var x true)

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -38,6 +38,8 @@
          (tonumber num))"
       [24 58 1999])
   (== "(icollect [_ x (ipairs [2 3]) :into [11]] (* x 11))"
+      [11 22 33])
+  (== "(icollect [:into [11] _ x (ipairs [2 3])] (* x 11))"
       [11 22 33]))
 
 (fn test-accumulate []

--- a/test/loops.fnl
+++ b/test/loops.fnl
@@ -43,6 +43,16 @@
       [11 22 33])
   (let [(ok? msg) (pcall fennel.compileString "(icollect [:into [] _ x (ipairs [2 3]) :into []] x)")]
     (l.assertFalse ok?)
+    (l.assertStrContains msg ":into clause"))
+  (== "(icollect [:into (#[11]) _ x (ipairs [2 3])] (* x 11))"
+      [11 22 33])
+  (== "(let [xs [11]] (icollect [_ x (ipairs [2 3]) :into xs] (* x 11)))"
+      [11 22 33])
+  (let [(ok? msg) (pcall fennel.compileString "(icollect [_ x (ipairs [2 3]) :into \"oops\"] x)")]
+    (l.assertFalse ok?)
+    (l.assertStrContains msg ":into clause"))
+  (let [(ok? msg) (pcall fennel.compileString "(icollect [_ x (ipairs [2 3]) :into 2] x)")]
+    (l.assertFalse ok?)
     (l.assertStrContains msg ":into clause")))
 
 (fn test-accumulate []


### PR DESCRIPTION
As discussed in irc:

1. Allows `:into` to appear anywhere (including as the first element in the binding table)
2. Relaxes type validation from "a literal table" to "a literal table, list, or symbol" -- so, excluding numbers or strings
3. Also added an assert that there's only one `:into` clause 