### PR TITLE
warn when a --native-module does not contain a luaopen_* symbol

### DIFF
--- a/src/fennel/binary.fnl
+++ b/src/fennel/binary.fnl
@@ -4,9 +4,7 @@
 
 ;; based on https://github.com/ers35/luastatic/
 (local fennel (require :fennel))
-
-(fn warn [warning]
-  (io.stderr:write (.. "WARNING: " warning "\n")))
+(local {: warn} (require :fennel.utils))
 
 (fn shellout [command]
   (let [f (io.popen command)

--- a/src/fennel/compiler.fnl
+++ b/src/fennel/compiler.fnl
@@ -747,9 +747,7 @@ which we have to do if we don't know."
 
 (fn require-include [ast scope parent opts]
   (fn opts.fallback [e]
-    (when (and _G.io _G.io.stderr)
-      (_G.io.stderr:write (.. "-- WARNING: include module not found, "
-                              "falling back to require: " (tostring e) "\n")))
+    (utils.warn (: "include module not found,- falling back to require: %s" :format e))
     (utils.expr (string.format "require(%s)" (tostring e)) :statement))
 
   (scopes.global.specials.include ast scope parent opts))

--- a/src/fennel/compiler.fnl
+++ b/src/fennel/compiler.fnl
@@ -747,7 +747,7 @@ which we have to do if we don't know."
 
 (fn require-include [ast scope parent opts]
   (fn opts.fallback [e]
-    (utils.warn (: "include module not found,- falling back to require: %s" :format e))
+    (utils.warn (: "include module not found,- falling back to require: %s" :format (tostring e)))
     (utils.expr (string.format "require(%s)" (tostring e)) :statement))
 
   (scopes.global.specials.include ast scope parent opts))

--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -9,7 +9,7 @@
 
 (fn warn [message]
   (when (and _G.io _G.io.stderr)
-    (_G.io.stderr:write (: "--WARNING: %s\n" :format message))))
+    (_G.io.stderr:write (: "--WARNING: %s\n" :format (tostring message)))))
 
 (fn stablepairs [t]
   "Like pairs, but gives consistent ordering every time. On 5.1, 5.2, and LuaJIT

--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -7,6 +7,10 @@
 
 ;;; General-purpose helper functions
 
+(fn warn [message]
+  (when (and _G.io _G.io.stderr)
+    (_G.io.stderr:write (: "--WARNING: %s\n" :format message))))
+
 (fn stablepairs [t]
   "Like pairs, but gives consistent ordering every time. On 5.1, 5.2, and LuaJIT
   pairs is already stable, but on 5.3+ every run gives different ordering. Gives
@@ -335,7 +339,8 @@ handlers will be skipped."
         ;; bootstrap compiler does not have :until support
         (lua "return result")))))
 
-{: allpairs
+{: warn
+ : allpairs
  : stablepairs
  : copy
  : kvmap

--- a/test/misc.fnl
+++ b/test/misc.fnl
@@ -39,12 +39,12 @@
         (ok6 out6) (pcall fennel.dofile "test/mod/foo6.fnl"
                           {:requireAsInclude true}
                           :test)]
-    (l.assertTrue ok out)
-    (l.assertTrue ok2 "Expected foo2 to run")
-    (l.assertTrue ok3 "Expected foo3 to run")
-    (l.assertTrue ok4 "Expected foo4 to run")
-    (l.assertTrue ok5 "Expected foo5 to run")
-    (l.assertTrue ok6 "Expected foo6 to run")
+    (l.assertTrue ok (: "Expected foo to run but it failed with error %s" :format (tostring out)))
+    (l.assertTrue ok2 (: "Expected foo2 to run but it failed with error %s" :format (tostring out2)))
+    (l.assertTrue ok3 (: "Expected foo3 to run but it failed with error %s" :format (tostring out3)))
+    (l.assertTrue ok4 (: "Expected foo4 to run but it failed with error %s" :format (tostring out4)))
+    (l.assertTrue ok5 (: "Expected foo5 to run but it failed with error %s" :format (tostring out5)))
+    (l.assertTrue ok6 (: "Expected foo6 to run but it failed with error %s" :format (tostring out6)))
     (l.assertEquals (and (= :table (type out)) out.result) expected
                     (.. "Expected include to have result: " expected))
     (l.assertFalse out.quux


### PR DESCRIPTION
Outputs a warning when you specify a `--native-module` that doesn't include a `luaopen_*` function.