### PR TITLE
Allow renaming native modules in compile binary

### DIFF
--- a/src/fennel/binary.fnl
+++ b/src/fennel/binary.fnl
@@ -280,7 +280,8 @@ int main(int argc, char *argv[]) {
       (when (= :--rename-native-module (. args i))
         (let [original (table.remove args (+ i 1))
               new (table.remove args (+ i 1))]
-          (tset native.rename-modules original new))))
+          (tset native.rename-modules original new)
+          (table.remove args i))))
     (when (< 0 (length args))
       (print (table.concat args " "))
       (error (.. "Unknown args: " (table.concat args " "))))

--- a/src/fennel/binary.fnl
+++ b/src/fennel/binary.fnl
@@ -179,12 +179,11 @@ int main(int argc, char *argv[]) {
                        "Did you mean to use --native-library instead of --native-module?")
                    :format path)))
         (each [_ open (ipairs opens)]
-          (let [maybe-rename (. rename open)
-                require-name (if maybe-rename
-                                 (do
-                                   (tset used-renames open true)
-                                   maybe-rename)
-                                 open)]
+          (let [require-name (match (. rename open)
+                               renamed (do
+                                         (tset used-renames open true)
+                                         renamed)
+                               _ open)]
             (table.insert out
                           (: "  int luaopen_%s(lua_State *L);" :format open))
             (table.insert out (: "  lua_pushcfunction(L, luaopen_%s);" :format

--- a/src/fennel/binary.fnl
+++ b/src/fennel/binary.fnl
@@ -4,7 +4,7 @@
 
 ;; based on https://github.com/ers35/luastatic/
 (local fennel (require :fennel))
-(local {: warn} (require :fennel.utils))
+(local {: warn : copy} (require :fennel.utils))
 
 (fn shellout [command]
   (let [f (io.popen command)
@@ -290,10 +290,9 @@ int main(int argc, char *argv[]) {
 (fn compile [filename executable-name static-lua lua-include-dir options args]
   (let [{: modules : libraries : rename-modules} (extract-native-args args)
         opts {: rename-modules}]
-    (each [key val (pairs options)]
-      (tset opts key val))
-    (compile-binary (write-c filename modules opts) executable-name
-                    static-lua lua-include-dir libraries)))
+    (copy options opts)
+    (compile-binary (write-c filename modules opts) executable-name static-lua
+                    lua-include-dir libraries)))
 
 (local help (: "
 Usage: %s --compile-binary FILE OUT STATIC_LUA_LIB LUA_INCLUDE_DIR


### PR DESCRIPTION
Allows using `--rename-native-module ORIGINAL NEW` to rename the require string used to require a given native module from `ORIGINAL` (which is taken from the suffix of the `luaopen_*` symbol(s) in the module) to `NEW`.

This is based on #393 and will be rebased onto `main` once that is merged.