### PR TITLE
require-macros hook

### DIFF
--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -1116,6 +1116,7 @@ modules in the compiler environment."
       (let [(loader filename) (search-macro-module modname 1)]
         (compiler.assert loader (.. modname " module not found.") ast)
         (tset macro-loaded modname (loader modname filename))))
+    (utils.hook :require-macros ast scope)
     ;; if we're called from import-macros, return the modname, else add them
     ;; to scope directly
     (if (= :import-macros (tostring (. ast 1)))

--- a/test/init.lua
+++ b/test/init.lua
@@ -32,7 +32,7 @@ local function testall(suites)
 end
 
 local suites = {"core", "mangling", "quoting", "bit", "fennelview", "parser",
-                "failures", "repl", "cli", "macro", "linter", "loops", "misc"}
+                "failures", "repl", "cli", "macro", "linter", "loops", "misc", "plugin"}
 
 if(#arg == 0) then
    local ok, err = pcall(testall, suites)

--- a/test/plugin.fnl
+++ b/test/plugin.fnl
@@ -1,0 +1,19 @@
+(local fennel (require :fennel))
+(local l (require :test.luaunit))
+
+(var ran-require-macros false)
+
+(local plugin
+  {:name :test-plugin
+   :version fennel.version
+   :require-macros (fn [ast scope]
+                     (set ran-require-macros true))})
+
+(local options {:plugins [plugin]})
+
+(fn test-require-macros []
+  "Check require-macros hook is trigered"
+  (let [src "(import-macros m :test.macros)"]
+    (l.assertEquals ran-require-macros false)))
+
+{: test-require-macros}


### PR DESCRIPTION
[Hotpot](https://github.com/rktjmp/hotpot.nvim) tracks "macro files" as dependencies for regular Fennel code, so if a macro is edited, any files that `import-macro`'d that file are also re-compiled.

It does this by a custom macro searcher, and a small patch to Fennel itself that disabled the `macro-loaded` cache, so that the searcher is always called (so every import passes through the searcher).

https://github.com/rktjmp/hotpot.nvim/commit/f9a4c29f5f4008765f830b44d2db6544eb3bc497

```diff
diff --git a/deps/fennel-0.10.0.lua b/deps/fennel-0.10.0.lua
index 9572c34..b18f4dd 100644
--- a/deps/fennel-0.10.0.lua
+++ b/deps/fennel-0.10.0.lua
@@ -2034,7 +2034,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     local modexpr = resolve_module_name(ast, scope, parent, {})
     local _ = compiler.assert((modexpr.type == "literal"), "module name must compile to string", (real_ast or ast))
     local modname = load_code(("return " .. modexpr[1]))()
-    if not macro_loaded[modname] then
+    if true or (not macro_loaded[modname]) then
       local env = make_compiler_env(ast, scope, parent)
       local loader, filename = search_macro_module(modname, 1)
       compiler.assert(loader, (modname .. " module not found."), ast)
```

This PR adds an new hook `required-macro` that passes the `modname`, which would let Hotpot use a compiler plugin instead and remove the need to patch Fennel.

I aware this:

- Doesn't conform to the other hooks (does not pass `ast` or `scope`), though `destructure` doesn't either. Perhaps it could pass `ast scope modname`.
- Doesn't really have the same "feel" as the other hooks, in terms of dealing with more technical aspects.
- Might be have a pretty slim use case, though I image other tools may want to do something similar to what Hotpot does.
- The "tense" of the name might be debated to, it's technically happening before the macro is really there?

Would something like this ever make it into Fennel or is it a bit too off the mark for what the compiler plugins are intended for?

```diff
diff --git a/src/fennel/specials.fnl b/src/fennel/specials.fnl
index 819e769..74195ea 100644
--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -1137,6 +1137,7 @@ modules in the compiler environment."
       (let [(loader filename) (search-macro-module modname 1)]
         (compiler.assert loader (.. modname " module not found.") ast)
         (tset macro-loaded modname (loader modname filename))))
+    (utils.hook :required-macro modname)
     (add-macros (. macro-loaded modname) ast scope parent)))
 
 (doc-special :require-macros [:macro-module-name]
```