### PR TITLE
Correct a few typos in documentation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -299,7 +299,7 @@ This release mostly contains small bug fixes.
 * Fix a bug causing `else` to emit twice in some contexts
 
 ### Changes and Removals
-* Dissallow naming a local the same as global in some contexts
+* Disallow naming a local the same as global in some contexts
 
 
 ## 0.3.1 / 2019-12-17

--- a/reference.md
+++ b/reference.md
@@ -696,9 +696,9 @@ this `begin` or `progn`.
 * `lshift`, `rshift`, `band`, `bor`, `bxor`, `bnot`: bitwise operations
 
 These all work as you would expect, with a few caveats. The bitwise operators
-are only availible in Lua 5.3+, unless you use the `--use-bit-lib` flag or
+are only available in Lua 5.3+, unless you use the `--use-bit-lib` flag or
 the `useBitLib` flag in the options table, which lets them be used in
-LuaJIT. The integer division operator (`//`) is only availible in Lua 5.3+.
+LuaJIT. The integer division operator (`//`) is only available in Lua 5.3+.
 
 They all take any number of arguments, as long as that number is fixed
 at compile-time. For instance, `(= 2 2 (unpack [2 5]))` will evaluate


### PR DESCRIPTION
Noticed a couple of typos and then ran spellcheck on the repository. 