### PR TITLE
Add embedded fennel documentation

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -103,6 +103,9 @@ table.insert(package.loaders or package.searchers, fennel.searcher)
 local mylib = require("mylib") -- will compile and load code in mylib.fnl
 ```
 
+You can pass [options](api.md) to the fennel compiler, by using `fennel.makeSearcher()` 
+instead of `fennel.searcher`.
+
 Be sure to use the `fennel.lua` library and not the file for the
 entire `fennel` executable.
 


### PR DESCRIPTION
Added a sentence on how to pass compiler options to the embedded fennel compiler.
Using fennel to configure/script the luakit browser and was running into the issue of unknown globals

Finding this method was not easy or quick and is possibly a common issue you can face when plugging fennel into a lua codebase.