### PR TITLE
Adding hashfn missing example

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -167,6 +167,7 @@ which wraps its single argument in a function literal. For example,
 ```fennel
 #$3               ; same as (fn [x y z] z)
 #[$1 $2 $3]       ; same as (fn [a b c] [a b c])
+#{:a $1 :b $2}    ; same as (fn [a b] {:a a :b b})
 #$                ; same as (fn [x] x) (aka the identity function)
 #val              ; same as (fn [] val)
 #[:one :two $...] ; same as (fn [...] ["one" "two" ...])


### PR DESCRIPTION
While upgrading my syntax highlighting package, I missed this example of possible hashfn literal in the reference:

`#{:a $1 :b $2 :c $3}`

```fnl
(local fennel (require :fennel))

(-> [2 4 6]
  (table.unpack)
  (#{:a $1 :b $2 :c $3})
  (fennel.view)
  (print)) ; => {:a 2 :b 4 :c 6}
```