### PR TITLE
Exposing varg?, macroPath, and macroSearchers in the Public API

### DIFF
--- a/src/fennel.fnl
+++ b/src/fennel.fnl
@@ -105,6 +105,7 @@
             :comment utils.comment
             :comment? utils.comment?
             :varg utils.varg
+            :varg? utils.varg?
             ;; parsing
             :sym-char? parser.sym-char?
             :parser parser.parser
@@ -146,6 +147,8 @@
             :make_searcher specials.make-searcher
             :makeSearcher specials.make-searcher
             :searchModule specials.search-module
+            :macroPath utils.macro-path
+            :macroSearchers specials.macro-searchers
             :macroLoaded specials.macro-loaded
             :compileStream compiler.compile-stream
             :compileString compiler.compile-string

--- a/test/api.fnl
+++ b/test/api.fnl
@@ -1,0 +1,91 @@
+(local l (require :test.luaunit))
+
+(local expected {
+  :comment         "function"
+  :comment?        "function"
+  :compile         "function"
+  :compile-stream  "function"
+  :compile-string  "function"
+  :doc             "function"
+  :dofile          "function"
+  :eval            "function"
+  :list            "function"
+  :list?           "function"
+  :load-code       "function"
+  :macro-loaded    "table"
+  :macro-path      "string"
+  :macro-searchers "table"
+  :make-searcher   "function"
+  :metadata        "table"
+  :parser          "function"
+  :path            "string"
+  :repl            "function"
+  :runtime-version "function"
+  :search-module   "function"
+  :searcher        "function"
+  :sequence        "function"
+  :sequence?       "function"
+  :sym             "function"
+  :sym-char?       "function"
+  :sym?            "function"
+  :syntax          "function"
+  :traceback       "function"
+  :varg            "function"
+  :varg?           "function"
+  :version         "string"
+  :view            "function"})
+
+(local expected-aliases {
+  :compileStream  "function"
+  :compileString  "function"
+  :loadCode       "function"
+  :macroLoaded    "table"
+  :macroPath      "string"
+  :macroSearchers "table"
+  :makeSearcher   "function"
+  :runtimeVersion "function"
+  :searchModule   "function"})
+
+(local expected-deprecations {
+  :compile1      "function"
+  :gensym        "function"
+  :granulate     "function"
+  :make_searcher "function"
+  :mangle        "function"
+  :scope         "function"
+  :string-stream "function"
+  :stringStream  "function"
+  :unmangle      "function"})
+
+(fn test-api-exposure []
+  (let [fennel (require :fennel) current {}]
+
+    (each [key value (pairs fennel)]
+      (tset current key (type value)))
+
+    (each [key kind (pairs expected)]
+      (l.assertNotNil (. fennel key) (.. "expect fennel." key " to exists"))
+      (l.assertEquals
+        (type (. fennel key)) kind
+        (.. "expect fennel." key " to be \"" kind "\"")))
+
+    (each [key kind (pairs expected-aliases)]
+      (l.assertNotNil (. fennel key) (.. "expect alias fennel." key " to exists"))
+      (l.assertEquals
+        (type (. fennel key)) kind
+        (.. "expect alias fennel." key " to be \"" kind "\"")))
+
+    (each [key kind (pairs expected-deprecations)]
+      (l.assertNotNil (. fennel key) (.. "expect deprecated fennel." key " to exists"))
+      (l.assertEquals
+        (type (. fennel key)) kind
+        (.. "expect deprecated fennel." key " to be \"" kind "\"")))
+
+    (each [key value (pairs fennel)]
+      (l.assertNotNil
+        (or (. expected key)
+            (. expected-aliases key)
+            (. expected-deprecations key))
+        (.. "fennel." key " not expected to be in the public api")))))
+
+{: test-api-exposure}

--- a/test/init.lua
+++ b/test/init.lua
@@ -33,7 +33,7 @@ end
 
 local suites = {"core", "mangling", "quoting", "bit", "fennelview", "parser",
                 "failures", "repl", "cli", "macro", "linter", "loops", "misc",
-                "searcher"}
+                "searcher", "api"}
 
 if(#arg == 0) then
    local ok, err = pcall(testall, suites)


### PR DESCRIPTION
The function `varg?` is expected to exist in the public API as `fennel.varg?`. The aliases `macroPath` and `macroSearchers` are important for Lua.

I believe that there is an intention to make the public API reliable. Removing or exposing something by accident may lead to breaking things or having to support things that we don't want to because people started to use them.

So, I'm proposing the creation of a kind of _contract testing_ for the public API. wdyt?

Also, some questions:

1) Should every function in the public API be available for Lua as well? If yes, would make sense to create the missing aliases?

```
comment?        => isComment
list?           => isList
macro-path      => macroPath
macro-searchers => macroSearchers
sequence?       => isSequence
sym-char?       => isSymChar
sym?            => isSym
symChar?        => isSymChar
varg?           => isVarg
```

2) May `make_searcher` be removed or deprecated in favor of `makeSearcher`?

Answers from the discussion on IRC:

1) `macroPath` and `macroSearchers` should, the others are unlikely to be used.

2) Too late for that, [make_searcher](https://github.com/search?l=Lua&q=make_searcher&type=Code) is already spread.