### PR TITLE
Pass correct filename to relative require expressions

### DIFF
--- a/src/fennel/macros.fnl
+++ b/src/fennel/macros.fnl
@@ -357,8 +357,13 @@ Example:
     ;; this is weird because require-macros is deprecated but it works.
     (let [(binding modname) (select i binding1 module-name1 ...)
           scope (get-scope)
-          macros* (_SPECIALS.require-macros `(import-macros ,modname)
-                                            scope {} binding1)]
+          ;; if the module-name is an expression (and not just a string) we
+          ;; patch our expression to have the correct source filename so
+          ;; require-macros can pass it down when resolving the module-name.
+          expr `(import-macros ,modname)
+          filename (if (list? modname) (. modname 1 :filename) :unknown)
+          _ (tset expr :filename filename)
+          macros* (_SPECIALS.require-macros expr scope {} binding1)]
       (if (sym? binding)
           ;; bind whole table of macros to table bound to symbol
           (tset scope.macros (. binding 1) macros*)

--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -1061,9 +1061,9 @@ Only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
     (fn find-in-path [start ?tried-paths]
       (match (fullpath:match pattern start)
         path (match (try-path path)
-          filename filename
-          (nil error) (find-in-path (+ start (length path) 1)
-                                    (doto (or ?tried-paths []) (table.insert error))))
+               filename filename
+               (nil error) (find-in-path (+ start (length path) 1)
+                                         (doto (or ?tried-paths []) (table.insert error))))
         _ (values nil
                   ;; Before Lua 5.4 it was necessary to prepend a \n\t to the
                   ;; error message. In newer versions doing so causes an empty

--- a/test/macro.fnl
+++ b/test/macro.fnl
@@ -85,6 +85,12 @@
 (fn test-relative-chained-mac-mod-mac []
   (== (require :test.relative-chained-mac-mod-mac) [:a :b :c]))
 
+(fn test-relative-filename []
+  ;; manual pcall instead of == macro for smaller failure message
+  (let [(ok? val) (pcall require :test.relative-filename)]
+    (l.assertTrue ok? "... had bad filename")
+    (l.assertEquals val 2)))
+
 (fn test-require-macros []
   (== (do (require-macros :test.macros) (->1 9 (+ 2) (* 11))) 121)
   (== (do (require-macros :test.macros)
@@ -308,6 +314,7 @@
  : test-require-macros
  : test-relative-macros
  : test-relative-chained-mac-mod-mac
+ : test-relative-filename
  : test-eval-compiler
  : test-inline-macros
  : test-macrodebug

--- a/test/relative-filename.fnl
+++ b/test/relative-filename.fnl
@@ -1,0 +1,18 @@
+(require-macros ((fn [mod fname]
+                   ;; this expression is evaluated by the compiler with
+                   ;; the current module and filename injected via ...
+                   ;; mod name is this module
+                   (assert (= mod :test.relative-filename))
+                   ;; filename is this file
+                   (assert (= fname :./test/relative-filename.fnl)
+                           "filename was incorrect")
+                   ;; return a good value as we are not testing this.
+                   (values :test.relative.macros)) ...))
+
+(import-macros {:inc i-inc} ((fn [mod fname]
+                               (assert (= mod :test.relative-filename))
+                               (assert (= fname :./test/relative-filename.fnl)
+                                       "filename was incorrect")
+                               ;; return a good value as we are not testing this.
+                               (values :test.relative.macros)) ...))
+(+ (i-inc 0) (inc 0))


### PR DESCRIPTION
When using "relative requires", the module name and module filename are passed into the code chunk when evaluating the "mod-name expression".

Currently this always uses the filename of the first expression, which ends up being `src/fennel/macros.fnl`. We can get the correct filename (the filename for the file that actually contains the "mod-name expression") from the next part of the AST.

It's probably pretty rare that someone wants to operate on the *filename* given inside the expression of a require, but it may as well be correct.