### PR TITLE
Make `fennel --eval` print all return values, fix test-arg

### DIFF
--- a/src/launcher.fnl
+++ b/src/launcher.fnl
@@ -52,11 +52,17 @@ If ~/.fennelrc exists, it will be loaded before launching a repl.")
 
 (local options {:plugins []})
 
+;; Lua 5.1 doesn't have table.pack
+;; necessary to preserve nils in luajit
+(fn pack [...]
+  (doto [...]
+    (tset :n (select :# ...))))
+
 (fn dosafely [f ...]
   (let [args [...]]
-    (match (xpcall #(f (unpack args)) fennel.traceback)
-      (true val) val
-      (_ msg) (do
+    (match (pack (xpcall #(f (unpack args)) fennel.traceback))
+      [true &as all] (unpack all 2 all.n)
+      [_ msg] (do
                 (io.stderr:write (.. msg "\n"))
                 (os.exit 1)))))
 

--- a/test/cli.fnl
+++ b/test/cli.fnl
@@ -18,7 +18,9 @@
 (fn test-cli []
   ;; skip this if we haven't compiled the CLI
   (when (file-exists? "./fennel")
-    (l.assertEquals [(peval "(+ 1 2 3)")] [true "6"])))
+    (l.assertEquals [(peval "(+ 1 2 3)")] [true "6"])
+    (l.assertEquals [(peval "(values 1 2)")] [true "1\t2"])
+    (l.assertEquals [(peval "(values 1 nil 2 nil nil)")] [true "1\tnil\t2\tnil\tnil"])))
 
 (fn test-lua-flag []
   ;; skip this when cli is not compiled or not running tests with `make testall`
@@ -47,12 +49,7 @@
 
 (fn test-args []
   (when true (and test-all? (file-exists? "./fennel"))
-    (let [code "(. arg 3)"
-          cmd (string.format "./fennel --eval %q -l" code)
-          proc (io.popen cmd)
-          output (: (proc:read :*a) :gsub "\n$" "")]
-      (l.assertTrue (proc:close))
-      (l.assertEquals output "-l"))))
+    (l.assertEquals [(peval "(. arg 3)" "-l")] [true "-l"])))
 
 {: test-cli
  : test-lua-flag


### PR DESCRIPTION
makes dosafely return the same number of values as the function it calls.
fixes test-arg not matching correct output.

this probably?? could use a test for the multiple return from dosafely, id be willing to implement one if yall could give some pointers