### PR TITLE
Add comparator generator for when all args are idempotent

### DIFF
--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -952,15 +952,15 @@ Only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
   (let [comparisons []
         vals []
         chain (string.format " %s " (or chain-op :and))]
-    (for [i 2 (length ast)]
-      (table.insert vals (tostring (. (compiler.compile1 (. ast i) scope parent
-                                                         {:nval 1})
-                                      1))))
-    (for [i 1 (- (length vals) 1)]
-      (table.insert comparisons
-                    (string.format "(%s %s %s)" (. vals i) op
-                                   (. vals (+ i 1)))))
-    (table.concat comparisons chain)))
+    (fcollect [i 2 (length ast) :into vals]
+      (tostring (. (compiler.compile1 (. ast i) scope parent
+                                      {:nval 1})
+                   1)))
+    (fcollect [i 1 (- (length vals) 1) :into comparisons]
+                            (string.format "(%s %s %s)"
+                                           (. vals i) op (. vals (+ i 1))))
+    (table.concat comparisons
+                  chain)))
 
 (fn double-eval-protected-comparator [op chain-op ast scope parent]
   "Compile a multi-arity comparison to a binary Lua comparison."
@@ -973,10 +973,9 @@ Only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
       (table.insert vals (tostring (. (compiler.compile1 (. ast i) scope parent
                                                          {:nval 1})
                                       1))))
-    (for [i 1 (- (length arglist) 1)]
-      (table.insert comparisons
-                    (string.format "(%s %s %s)" (. arglist i) op
-                                   (. arglist (+ i 1)))))
+    (fcollect [i 1 (- (length arglist) 1) :into comparisons]
+      (string.format "(%s %s %s)" (. arglist i) op
+                     (. arglist (+ i 1))))
     ;; The function call here introduces some overhead, but it is the only way
     ;; to compile this safely while preventing both double-evaluation of
     ;; side-effecting values and early evaluation of values which should never

--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -992,7 +992,7 @@ Only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
       (compiler.assert (< 2 (length ast)) "expected at least two arguments" ast)
       (if (= 3 (length ast))
           (native-comparator op ast scope parent)
-          (utils.every utils.idempotent-expr? [(unpack ast 2)])
+          (utils.every? utils.idempotent-expr? [(unpack ast 2)])
           (idempotent-comparator op ?chain-op ast scope parent)
           (double-eval-protected-comparator op ?chain-op ast scope parent)))
 

--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -949,16 +949,14 @@ Only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
 (fn idempotent-comparator [op chain-op ast scope parent]
   "Compile a multi-arity comparison to a binary Lua comparison. Optimized
   variant for values not at risk of double-eval."
-  (let [comparisons []
-        vals []
+  (let [vals (fcollect [i 2 (length ast)]
+               (tostring (. (compiler.compile1 (. ast i) scope parent
+                                               {:nval 1})
+                            1)))
+        comparisons (fcollect [i 1 (- (length vals) 1)]
+                      (string.format "(%s %s %s)"
+                                     (. vals i) op (. vals (+ i 1))))
         chain (string.format " %s " (or chain-op :and))]
-    (fcollect [i 2 (length ast) :into vals]
-      (tostring (. (compiler.compile1 (. ast i) scope parent
-                                      {:nval 1})
-                   1)))
-    (fcollect [i 1 (- (length vals) 1) :into comparisons]
-                            (string.format "(%s %s %s)"
-                                           (. vals i) op (. vals (+ i 1))))
     (table.concat comparisons
                   chain)))
 

--- a/src/fennel/specials.fnl
+++ b/src/fennel/specials.fnl
@@ -992,7 +992,7 @@ Only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
       (compiler.assert (< 2 (length ast)) "expected at least two arguments" ast)
       (if (= 3 (length ast))
           (native-comparator op ast scope parent)
-          (utils.every utils.idempotent-expr? (table.pack (table.unpack ast 2)))
+          (utils.every utils.idempotent-expr? [(unpack ast 2)])
           (idempotent-comparator op ?chain-op ast scope parent)
           (double-eval-protected-comparator op ?chain-op ast scope parent)))
 

--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -128,12 +128,11 @@ Optionally takes a target table to insert the mapped values into."
   (accumulate [max 0 k (pairs tbl)]
     (if (= :number (type k)) (math.max max k) max)))
 
-(fn every [predicate seq]
-  (each [_ item (ipairs seq)]
-        (when (not (predicate item))
-          ;; use escape hatch for early return optimization
-          (lua "return false")))
-  true)
+(fn every? [predicate seq]
+  (accumulate [result true
+               _ item (ipairs seq)
+               &until (not result)]
+    (predicate item)))
 
 (fn allpairs [tbl]
   "Like pairs, but if the table has an __index metamethod, it will recurisvely
@@ -443,7 +442,7 @@ handlers will be skipped."
  : walk-tree
  : member?
  : maxn
- : every
+ : every?
  : list
  : sequence
  : sym

--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -128,6 +128,13 @@ Optionally takes a target table to insert the mapped values into."
   (accumulate [max 0 k (pairs tbl)]
     (if (= :number (type k)) (math.max max k) max)))
 
+(fn every [predicate seq]
+  (each [_ item (ipairs seq)]
+        (when (not (predicate item))
+          ;; use escape hatch for early return optimization
+          (lua "return false")))
+  true)
+
 (fn allpairs [tbl]
   "Like pairs, but if the table has an __index metamethod, it will recurisvely
 traverse upwards, skipping duplicates, to iterate all inherited properties"
@@ -319,6 +326,14 @@ Returns nil if passed something other than a multi-sym."
 (fn quoted? [symbol]
   symbol.quoted)
 
+(fn idempotent-expr? [x]
+  "Checks if an object is an idempotent expression. Returns the object if it is."
+  (or (= (type x) :string)
+      (= (type x) :integer)
+      (= (type x) :number)
+      (and (sym? x)
+           (not (multi-sym? x)))))
+
 (fn ast-source [ast]
   "Get a table for the given ast which includes file/line info, if possible."
   (if (or (table? ast) (sequence? ast)) (or (getmetatable ast) {})
@@ -428,6 +443,7 @@ handlers will be skipped."
  : walk-tree
  : member?
  : maxn
+ : every
  : list
  : sequence
  : sym
@@ -444,6 +460,7 @@ handlers will be skipped."
  : varg?
  : quoted?
  : string?
+ : idempotent-expr?
  : valid-lua-identifier?
  : lua-keywords
  : hook

--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -131,7 +131,7 @@ Optionally takes a target table to insert the mapped values into."
 (fn every? [predicate seq]
   (accumulate [result true
                _ item (ipairs seq)
-               &until (not result)]
+               :until (not result)]
     (predicate item)))
 
 (fn allpairs [tbl]


### PR DESCRIPTION
This adds an optimized comparator generator for when all of the arguments are literals or simple (non-multi) symbols (which almost certainly means a simple lexenv lookup). In this version, don't bother wrapping any of the comparison values in an anonymous function since evaluation of the args is idempotent.

This is actually a targeted fix for reducing the memory usage of [char-starter?](https://github.com/bakpakin/Fennel/blob/main/src/fennel/parser.fnl#L61); I'm trying to run Fennel in a low-memory environment (<= 4MB) and when I tried profiling `require("fennel")` with https://github.com/pmusa/lmprof to see where I could find some optimization opportunities, this was one of the indicated hotspots. Creating and immediately throwing away anonymous functions is not *super great* for memory use, and I noticed that this was a compiler enhancement opportunity: recognize when you have idempotent values and elide the function.

I ran the tests and they still pass. I'm 99% confident that this won't break other code; I was pretty simplistic and conservative about what values were considered idempotent, but my understanding might be flawed or incomplete.