### PR TITLE
add new plugin extension point `preprocess`

### DIFF
--- a/api.md
+++ b/api.md
@@ -618,6 +618,7 @@ the rest of the plugins for a given event to be skipped.
 * `destructure`
 * `parse-error`
 * `assert-compile`
+* `preprocess`
 
 The `destructure` extension point is different because instead of just
 taking `ast` and `scope` it takes a `from` which is the AST for the value

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@ deprecated forms.
   redefinition at runtime.
 * Allow following docstring with a metadata table syntax.
 * Return whole metadata table when `metadata.get` is called without a key.
+* added plugin extension point `preprocess`
 
 ## 1.3.0 / 2023-02-13
 

--- a/src/fennel/compiler.fnl
+++ b/src/fennel/compiler.fnl
@@ -860,7 +860,8 @@ which we have to do if we don't know."
     (compile-asts asts opts)))
 
 (fn compile-string [str ?opts]
-  (compile-stream (parser.string-stream str (or ?opts {})) (or ?opts {})))
+  (compile-stream (parser.string-stream (or (utils.hook-opts :preprocess ?opts str ?opts.filename) str)
+                                        (or ?opts {})) (or ?opts {})))
 
 (fn compile [ast ?opts]
   (compile-asts [ast] ?opts))


### PR DESCRIPTION
can be used to preprocess the source code just before compilation step or when implementing parser macros