### PR TITLE
Add option for additional Lua keywords

### DIFF
--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -384,6 +384,9 @@ When f returns a truthy value, recursively walks the children."
                      :while true
                      :goto true})
 
+(fn add-lua-keyword [str]
+  (tset lua-keywords str true))
+
 (fn valid-lua-identifier? [str]
   (and (str:match "^[%a_][%w_]*$") (not (. lua-keywords str))))
 
@@ -480,6 +483,7 @@ handlers will be skipped."
  : string?
  : idempotent-expr?
  : valid-lua-identifier?
+ : add-lua-keyword
  : lua-keywords
  : hook
  : hook-opts

--- a/src/launcher.fnl
+++ b/src/launcher.fnl
@@ -1,6 +1,7 @@
 ;; This is the command-line entry point for Fennel.
 
 (local fennel (require :fennel))
+(local utils (require :fennel.utils))
 (local unpack (or table.unpack _G.unpack))
 
 (local help "Usage: fennel [FLAG] [FILE]
@@ -34,6 +35,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --raw-errors             : Disable friendly compile error reporting
   --no-searcher            : Skip installing package.searchers entry
   --no-fennelrc            : Skip loading ~/.fennelrc when launching repl
+  --keywords K1[,K2...]    : Treat these symbols as reserved Lua keywords
 
   --help (-h)              : Display this text
   --version (-v)           : Show version
@@ -177,6 +179,10 @@ If ~/.fennelrc exists, it will be loaded before launching a repl.")
                       plugin (fennel.dofile (table.remove arg (+ i 1)) opts)]
                   (table.insert options.plugins 1 plugin)
                   (table.remove arg i))
+      :--keywords (do
+                    (each [keyword (string.gmatch (table.remove arg (+ i 1)) "[^,]+")]
+                      (utils.add-lua-keyword keyword))
+                    (table.remove arg i))
       _ (do
           (when (not (. commands (. arg i)))
             (set options.ignore-options true)


### PR DESCRIPTION
This PR adds the `--keyword` option to improve support for Lua forks which have additional keywords, as suggested in #459.

This option only affects the generated code, i.e. fennel generates correct code if this option is used.
Therefore this option will not allow Fennel to run on a Lua fork, if any added reserved names are used by Fennel itself (for example the Pluto keyword `new` is used by Fennel). However it should be possible to compile Fennel with this option to prevent this issue. 

I have tested this with [Ravi](https://github.com/dibyendumajumdar/ravi) and [Pluto](https://pluto-lang.org/):

- Ravi (`--keywords defer,C__decl,C__unsafe,C__new`):
  - Fennel can run on Ravi without changes and generates correct Ravi code
- Pluto (`--keywords switch,continue,enum,new,class,parent,export,try,catch`):
  - Fennel can't run on Pluto without changes but generates correct Pluto code


If this functionality gets added, it leads to a few questions that i can not answer:
- Does it make sense to document the forks with their keywords in the wiki?
- Should this option be added to the bootstrap compiler?
- Should Fennel detect these forks to:
  - show the correct vm name/version in the welcome message?
  - add a notice to use this option in the welcome message?
  - automatically add the keywords?