### PR TITLE
Add option for additional Lua keywords (using the options table)

### DIFF
--- a/api.md
+++ b/api.md
@@ -39,6 +39,8 @@ usually accept these fields:
 * `unfriendly`: disable friendly compiler/parser error messages.
 * `plugins`: list of compiler [plugins](#plugins).
 * `error-pinpoint`: a list of two strings indicating what to wrap compile errors in
+* `keywords`: a table of the form `{:keyword1 true :keyword2 true}` containing
+  symbols that should be treated as reserved Lua keywords.
 
 You can pass the string `"_COMPILER"` as the value for `env`; it will
 cause the code to be run/compiled in a context which has all

--- a/man/man1/fennel.1
+++ b/man/man1/fennel.1
@@ -97,6 +97,9 @@ for details.
 .B \-\-no\-compiler\-sandbox
 Do not limit compiler environment (used in macros) to minimal sandbox.
 .TP
+.B \-\-keywords \fIKEYWORD1[,KEYWORD2...]\fP
+Treat these symbols as reserved Lua keywords.
+.TP
 .B \-h, \-\-help
 Print a help message and exit
 .TP

--- a/src/fennel/compiler.fnl
+++ b/src/fennel/compiler.fnl
@@ -114,7 +114,7 @@ symbol is unique if the input string is unique in the scope."
   (assert-compile (not (utils.multi-sym? str))
                   (.. "unexpected multi symbol " str) ast)
   (let [;; Mapping mangling to a valid Lua identifier
-        raw (if (or (. utils.lua-keywords str) (str:match "^%d"))
+        raw (if (or (utils.lua-keyword? str) (str:match "^%d"))
                 (.. "_" str)
                 str)
         mangling (-> raw

--- a/src/fennel/repl.fnl
+++ b/src/fennel/repl.fnl
@@ -295,11 +295,11 @@ For more information about the language, see https://fennel-lang.org/reference")
 (compiler.metadata:set commands.doc :fnl/docstring
                        "Print the docstring and arglist for a function, macro, or special form.")
 
-(fn commands.compile [env read on-values on-error scope]
+(fn commands.compile [env read on-values on-error scope _ keywords]
   (run-command read on-error
                #(let  [allowedGlobals (specials.current-global-names env)
                        (ok? result) (pcall compiler.compile
-                                           $ {: env : scope : allowedGlobals})]
+                                           $ {: env : scope : allowedGlobals : keywords})]
                   (if ok?
                       (on-values [result])
                       (on-error :Repl (.. "Error compiling expression: " result))))))
@@ -316,10 +316,10 @@ For more information about the language, see https://fennel-lang.org/reference")
       (case (name:match "^repl%-command%-(.*)")
         cmd-name (tset commands cmd-name f)))))
 
-(fn run-command-loop [input read loop env on-values on-error scope chars]
+(fn run-command-loop [input read loop env on-values on-error scope chars keywords]
   (let [command-name (input:match ",([^%s/]+)")]
     (case (. commands command-name)
-      command (command env read on-values on-error scope chars)
+      command (command env read on-values on-error scope chars keywords)
       _ (when (and (not= command-name :exit) (not= command-name :return))
           (on-values ["Unknown command" command-name])))
     (when (not= :exit command-name)
@@ -433,7 +433,8 @@ For more information about the language, see https://fennel-lang.org/reference")
             (command? src-string)
             (run-command-loop src-string read loop env
                               callbacks.onValues callbacks.onError
-                              opts.scope chars)
+                              opts.scope chars
+                              opts.keywords)
             (when not-eof?
               (case-try (pcall compiler.compile form
                                (doto opts (tset :source src-string)))

--- a/src/launcher.fnl
+++ b/src/launcher.fnl
@@ -34,6 +34,7 @@ Run fennel, a lisp programming language for the Lua runtime.
   --raw-errors             : Disable friendly compile error reporting
   --no-searcher            : Skip installing package.searchers entry
   --no-fennelrc            : Skip loading ~/.fennelrc when launching repl
+  --keywords K1[,K2...]    : Treat these symbols as reserved Lua keywords
 
   --help (-h)              : Display this text
   --version (-v)           : Show version
@@ -52,7 +53,7 @@ Use the NO_COLOR environment variable to disable escape codes in error messages.
 
 If ~/.fennelrc exists, it will be loaded before launching a repl.")
 
-(local options {:plugins []})
+(local options {:plugins [] :keywords {}})
 
 ;; Lua 5.1 doesn't have table.pack
 ;; necessary to preserve nils in luajit
@@ -177,6 +178,10 @@ If ~/.fennelrc exists, it will be loaded before launching a repl.")
                       plugin (fennel.dofile (table.remove arg (+ i 1)) opts)]
                   (table.insert options.plugins 1 plugin)
                   (table.remove arg i))
+      :--keywords (do
+                    (each [keyword (string.gmatch (table.remove arg (+ i 1)) "[^,]+")]
+                      (tset options.keywords keyword true))
+                    (table.remove arg i))
       _ (do
           (when (not (. commands (. arg i)))
             (set options.ignore-options true)


### PR DESCRIPTION
Identical to #476, but implemented using the options table.

This change allows correct code to be generated when running Fennel code, compiling Fennel code to Lua and in the repl, including the `,compile` repl command.