### PR TITLE
Fix bug in apropos REPL commands

### DIFF
--- a/src/fennel/repl.fnl
+++ b/src/fennel/repl.fnl
@@ -206,9 +206,7 @@ For more information about the language, see https://fennel-lang.org/reference")
   ;; _G. part is stripped from patterns to provide more stable output.
   ;; The order we traverse package.loaded is arbitrary, so we may see
   ;; top level functions either as is or under the _G module.
-  (let [names (apropos* pattern package.loaded "" {} [])]
-    (icollect [_ name (ipairs names)]
-      (name:gsub "^_G%." ""))))
+  (apropos* (pattern:gsub "^_G%." "") package.loaded "" {} []))
 
 (fn commands.apropos [_env read on-values on-error _scope]
   (run-command read on-error #(on-values (apropos (tostring $)))))


### PR DESCRIPTION
Fix bug described in https://github.com/bakpakin/Fennel/issues/462 by stripping `_.G` from the input rather than the output of the `apropos*` function. This appears to have been the original intended behavior as described by the comment on [line 206](https://github.com/bakpakin/Fennel/blob/main/src/fennel/repl.fnl#L206).