### PR TITLE
check if arugment to `sym` is a string

### DIFF
--- a/src/fennel/utils.fnl
+++ b/src/fennel/utils.fnl
@@ -205,6 +205,7 @@ they are specifically not cons cells."
 not exposed outside the compiler. Second optional argument is a table describing
 where the symbol came from; should be a table with filename, line, bytestart,
 and byteend fields."
+  (assert (= (type str) :string) (.. "sym expects a string as the first argument, received " (type str)))
   (setmetatable (collect [k v (pairs (or ?source [])) :into [str]]
                   (if (= (type k) :string) (values k v)))
                 symbol-mt))

--- a/test/macro.fnl
+++ b/test/macro.fnl
@@ -807,6 +807,20 @@
   (t.= {1 :a 3 :c 5 :e :n 5} (macro-wrap pack (pack :a nil :c nil :e))
        "pack is in compiler-env"))
 
+(fn test-sym []
+  (macro use-sym [arg]
+    `(do ,(sym arg)))
+
+  (t.= "(do something)"
+       (macrodebug (use-sym "something") true)
+       "constructing a symbol from string should not fail")
+
+  (let [(ok? err) (pcall fennel.eval "(do
+                                       (macro use-sym [arg] `(do ,(sym arg)))
+                                       (use-sym something))")]
+    (t.is (not ok?))
+    (t.match ".*sym expects a string as the first argument.*" err)))
+
 {:teardown #(each [k (pairs fennel.repl)]
               (tset fennel.repl k nil))
  : test-arrows
@@ -832,4 +846,5 @@
  : test-case-try
  : test-lambda
  : test-literal
- : test-env-lua-helpers}
+ : test-env-lua-helpers
+ : test-sym}


### PR DESCRIPTION
Added an assertion to check if the first argument to `sym` is a string.

resolves #497